### PR TITLE
remove deprecate method call in InferenceATF

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -198,15 +198,14 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    @SuppressWarnings( "deprecation" ) //for getRealTypeFactory
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
         final Set<Class<? extends Annotation>> typeQualifiers = new HashSet<>();
 
         typeQualifiers.add(Unqualified.class);
         typeQualifiers.add(VarAnnot.class);
 
-        typeQualifiers.addAll(InferenceMain.getInstance().getRealTypeFactory().getSupportedTypeQualifiers());
-        return Collections.unmodifiableSet(typeQualifiers);
+        typeQualifiers.addAll(this.realTypeFactory.getSupportedTypeQualifiers());
+        return typeQualifiers;
     }
 
 

--- a/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
+++ b/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
@@ -104,7 +104,7 @@ public class SimpleFlowAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             res.add(Source.class);
             res.add(PolySource.class);
         }
-        return Collections.unmodifiableSet(res);
+        return res;
     }
 
     private AnnotationMirror buildAnnotationMirrorFlowPermission(


### PR DESCRIPTION
1. removed deprecate method call `InferenceMain#getRealTypeFactory()`

2. let `createSupportedTypeQualifiers()` return fresh set.

3. This PR depends on [opprop/checker-framework #1](https://github.com/opprop/checker-framework/pull/1)