### PR TITLE
add default target classpath in inferenceOptions

### DIFF
--- a/src/checkers/inference/InferenceOptions.java
+++ b/src/checkers/inference/InferenceOptions.java
@@ -72,7 +72,7 @@ public class InferenceOptions {
     public static String solver;
 
     @Option("The fully-qualified name of the classpath for target program; overrides --targetclasspath.")
-    public static String targetclasspath;
+    public static String targetclasspath = ".";
 
     @Option("Args to pass to solver, in the format key1=value,key2=value")
     public static String solverArgs;


### PR DESCRIPTION
When `javac` compiles a java file, the default classpath of this target file is current working directory `./`

To make `CF Inference` consist with `javac`, I add a default value of `InferenceOptions#targetclasspath` as `.`

This could let a user save the explicit declaration of the classpath of a target program when the classpath is just the default current working directory.