### PR TITLE
only call postInit when implicit this is InferenceATF itself.

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -151,7 +151,10 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                                                               unqualified, varAnnot, variableAnnotator);
 
         inferencePoly = new InferenceQualifierPolymorphism(slotManager, variableAnnotator, varAnnot);
-        postInit();
+     // Every subclass must call postInit!
+        if (this.getClass().equals(InferenceAnnotatedTypeFactory.class)) {
+            this.postInit();
+        }
     }
 
     @Override


### PR DESCRIPTION
`postInit()` method in `AnnotatedTypeFactory` should be called by the real runtime class during initialisation.

Otherwise, it may cause using uninitialised fields in a subclass during executing `postInit()`, which would cause some tricky exceptions. 

Currently, it seems we should follow the pattern in `BaseTypeATF`:

https://github.com/typetools/checker-framework/blob/master/framework/src/org/checkerframework/common/basetype/BaseAnnotatedTypeFactory.java#L25

Is there any better design to avoid forcing each subclass call the `postInit()`? @wmdietl @Jianchu @topnessman 
