### PR TITLE
add cfArgs in InferenceOptions. also parsing method in InferenceMain

### DIFF
--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -172,6 +172,7 @@ public class InferenceLauncher {
         addIfNotNull("--logLevel", InferenceOptions.logLevel, argList);
         addIfNotNull("--solver", InferenceOptions.solver, argList);
         addIfNotNull("--solverArgs", InferenceOptions.solverArgs, argList);
+        addIfNotNull("--cfArgs", InferenceOptions.cfArgs, argList);
 
         addIfTrue("--hacks", InferenceOptions.hacks, argList);
 

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -156,6 +156,10 @@ public class InferenceMain {
                 "-AprintErrorStack",
                 "-Awarns"));
 
+        if (InferenceOptions.cfArgs != null) {
+            checkerFrameworkArgs.addAll(parseCfArgs());
+        }
+
         if (InferenceOptions.logLevel == null) {
             InferenceUtil.setLoggingLevel(Level.FINE);
         } else {
@@ -362,6 +366,22 @@ public class InferenceMain {
             }
         }
         return processed;
+    }
+
+    /**
+     * Parse checker framework args from a space separated list of
+     * -Axxx=xxx,y=y -Azzz=zzz
+     * @return List of Strings, each string is a checker framework argument
+     * in the format: -Axxx=xxx,y=y or -Azzz or -Azzz=zzz
+     */
+    private List<String> parseCfArgs() {
+        List<String> argList = new ArrayList<>();
+        if (InferenceOptions.cfArgs != null) {
+            String cfArgs = InferenceOptions.cfArgs;
+            String[] split = cfArgs.split(" ");
+            argList.addAll(Arrays.asList(split));
+        }
+        return argList;
     }
 
     public static InferenceMain getInstance() {

--- a/src/checkers/inference/InferenceOptions.java
+++ b/src/checkers/inference/InferenceOptions.java
@@ -78,6 +78,9 @@ public class InferenceOptions {
     @Option("Args to pass to solver, in the format key1=value,key2=value")
     public static String solverArgs;
 
+    @Option("Args to pass to checker framework, in the format -Axxx=xxx -Ayyy=yyy,z=z")
+    public static String cfArgs;
+
     /** If jsonFile is specified this will be set to the JsonSerializerSolver */
     @Option("The JSON file to which constraints should be dumped.  This field is mutually exclusive with solver.")
     public static String jsonFile;


### PR DESCRIPTION
add cfArgs option in `InferenceOption`. 

User could use follow a space-seperated format to pass cfArgs when launching CF Inference:

```bash
--cfArgs="-Axxx=xxx -Ayyy"
```