### PR TITLE
Make SlotManager#nextId private

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -299,7 +299,6 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(variableSlot);
             locationCache.put(location, variableSlot.getId());
         }
-
         return variableSlot;
     }
 
@@ -314,7 +313,6 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(refinementVariableSlot);
             locationCache.put(location, refinementVariableSlot.getId());
         }
-
         return refinementVariableSlot;
     }
 
@@ -329,7 +327,6 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(constantSlot);
             constantCache.put(value, constantSlot.getId());
         }
-
         return constantSlot;
     }
 
@@ -345,7 +342,6 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(combVariableSlot);
             combSlotPairCache.put(pair, combVariableSlot.getId());
         }
-
         return combVariableSlot;
     }
 
@@ -361,7 +357,6 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(existentialVariableSlot);
             existentialSlotPairCache.put(pair, existentialVariableSlot.getId());
         }
-
         return existentialVariableSlot;
     }
 

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -130,10 +130,10 @@ public class DefaultSlotManager implements SlotManager {
     }
 
     /**
-     * @inheritDoc
+     * Returns the next unique variable id.  These id's are monotonically increasing.
+     * @return the next variable id to be used in VariableCreation
      */
-    @Override
-    public int nextId() {
+    private int nextId() {
         return nextId++;
     }
 
@@ -299,6 +299,8 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(variableSlot);
             locationCache.put(location, variableSlot.getId());
         }
+
+        assert variableSlot != null;
         return variableSlot;
     }
 
@@ -313,6 +315,8 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(refinementVariableSlot);
             locationCache.put(location, refinementVariableSlot.getId());
         }
+
+        assert refinementVariableSlot != null;
         return refinementVariableSlot;
     }
 
@@ -327,6 +331,8 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(constantSlot);
             constantCache.put(value, constantSlot.getId());
         }
+
+        assert constantSlot != null;
         return constantSlot;
     }
 
@@ -342,6 +348,8 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(combVariableSlot);
             combSlotPairCache.put(pair, combVariableSlot.getId());
         }
+
+        assert combVariableSlot != null;
         return combVariableSlot;
     }
 
@@ -357,6 +365,8 @@ public class DefaultSlotManager implements SlotManager {
             addToVariables(existentialVariableSlot);
             existentialSlotPairCache.put(pair, existentialVariableSlot.getId());
         }
+
+        assert existentialVariableSlot != null;
         return existentialVariableSlot;
     }
 

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -300,7 +300,6 @@ public class DefaultSlotManager implements SlotManager {
             locationCache.put(location, variableSlot.getId());
         }
 
-        assert variableSlot != null;
         return variableSlot;
     }
 
@@ -316,7 +315,6 @@ public class DefaultSlotManager implements SlotManager {
             locationCache.put(location, refinementVariableSlot.getId());
         }
 
-        assert refinementVariableSlot != null;
         return refinementVariableSlot;
     }
 
@@ -332,7 +330,6 @@ public class DefaultSlotManager implements SlotManager {
             constantCache.put(value, constantSlot.getId());
         }
 
-        assert constantSlot != null;
         return constantSlot;
     }
 
@@ -349,7 +346,6 @@ public class DefaultSlotManager implements SlotManager {
             combSlotPairCache.put(pair, combVariableSlot.getId());
         }
 
-        assert combVariableSlot != null;
         return combVariableSlot;
     }
 
@@ -366,7 +362,6 @@ public class DefaultSlotManager implements SlotManager {
             existentialSlotPairCache.put(pair, existentialVariableSlot.getId());
         }
 
-        assert existentialVariableSlot != null;
         return existentialVariableSlot;
     }
 

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -22,12 +22,6 @@ import checkers.inference.model.VariableSlot;
 public interface SlotManager {
 
     /**
-     * Returns the next unique variable id.  These id's are monotonically increasing.
-     * @return the next variable id to be used in VariableCreation
-     */
-    int nextId();
-
-    /**
      * Return number of slots collected by this SlotManager
      *
      * @return number of slots collected by this SlotManager

--- a/src/checkers/inference/model/serialization/CnfVecIntSerializer.java
+++ b/src/checkers/inference/model/serialization/CnfVecIntSerializer.java
@@ -151,7 +151,7 @@ public abstract class CnfVecIntSerializer implements Serializer<VecInt[], VecInt
         //TODO: WE SHOULD INSTEAD PIPE THROUGH THE ExistentialVariable ID
         Integer existentialId = existentialToPotentialVar.get(constraint.getPotentialVariable().getId());
         if (existentialId == null) {
-            existentialId = slotManager.nextId();
+            existentialId = slotManager.getNumberOfSlots() + existentialToPotentialVar.size() + 1;
             this.existentialToPotentialVar.put(new Integer(existentialId), new Integer(constraint.getPotentialVariable().getId()));
         }
 

--- a/src/checkers/inference/model/serialization/CnfVecIntSerializer.java
+++ b/src/checkers/inference/model/serialization/CnfVecIntSerializer.java
@@ -151,6 +151,9 @@ public abstract class CnfVecIntSerializer implements Serializer<VecInt[], VecInt
         //TODO: WE SHOULD INSTEAD PIPE THROUGH THE ExistentialVariable ID
         Integer existentialId = existentialToPotentialVar.get(constraint.getPotentialVariable().getId());
         if (existentialId == null) {
+            // existentialId should not overlap with the Id of real slots in slot manager
+            // thus by computing sum of total slots number in slot manager
+            // and the size of existentialToPotentialVar and plus 1 to get next id of existential Id here
             existentialId = slotManager.getNumberOfSlots() + existentialToPotentialVar.size() + 1;
             this.existentialToPotentialVar.put(new Integer(existentialId), new Integer(constraint.getPotentialVariable().getId()));
         }

--- a/src/checkers/inference/solver/MaxSat2TypeSolver.java
+++ b/src/checkers/inference/solver/MaxSat2TypeSolver.java
@@ -77,7 +77,8 @@ public class MaxSat2TypeSolver implements InferenceSolver {
         //if an exception occurs while creating a variable the id might be incremented
         //but the slot might not actually be recorded.  Therefore, nextId is NOT
         //the number of slots but the maximum you might encounter.
-        final int totalVars = slotManager.getNumberOfSlots();
+        // TODO: add documentation here if pass travis test
+        final int totalVars = slotManager.getNumberOfSlots() + serializer.getExistentialToPotentialVar().size();
         final int totalClauses =  clauses.size();
 
 

--- a/src/checkers/inference/solver/MaxSat2TypeSolver.java
+++ b/src/checkers/inference/solver/MaxSat2TypeSolver.java
@@ -77,7 +77,10 @@ public class MaxSat2TypeSolver implements InferenceSolver {
         //if an exception occurs while creating a variable the id might be incremented
         //but the slot might not actually be recorded.  Therefore, nextId is NOT
         //the number of slots but the maximum you might encounter.
-        // TODO: add documentation here if pass travis test
+        // TODO: this is a workaround as currently when serialize existential constraint we lost the real existential
+        // TODO: variable id and create "fake" id stored in existentialToPotentialVar map.
+        // TODO: thus here the value of totalVars is the real slots number stored in slotManager, and plus the 
+        // TODO: "fake" slots number stored in existentialToPotentialVar
         final int totalVars = slotManager.getNumberOfSlots() + serializer.getExistentialToPotentialVar().size();
         final int totalClauses =  clauses.size();
 


### PR DESCRIPTION
`SlotManager#nextId()` is better to be a private method as the discussion here:

- pascaliUWat/checker-framework-inference#3
- https://github.com/opprop/generic-type-inference-solver/pull/6

This PR makes `nextId()` private and clean up the `nextId()` usage in checker-framework-inference