### PR TITLE
Fixed wrong usage of qualifierHierarchy in ConstraintManager.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 matrix:
 env:
-  # - JDKVER=jdk7
+  - JDKVER=jdk7
   - JDKVER=jdk8
 
 # This is essential lest the script is ignored and Travis just runs gradle.

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -158,6 +158,10 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     }
 
+    public QualifierHierarchy getRealQualifierHierarchy() {
+        return realTypeFactory.getQualifierHierarchy();
+    }
+
     @Override
     protected CFAnalysis createFlowAnalysis(List<Pair<VariableElement, CFValue>> fieldValues) {
         return realChecker.createInferenceAnalysis(inferenceChecker, this, fieldValues, slotManager, constraintManager, realChecker);

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -158,6 +158,10 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     }
 
+    /**
+     * Get the real qualifier hierarchy from {@link #realTypeFactory}.
+     * @return the real qualifier hierarchy.
+     */
     public QualifierHierarchy getRealQualifierHierarchy() {
         return realTypeFactory.getQualifierHierarchy();
     }

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -303,7 +303,7 @@ public class InferenceMain {
         if (inferenceTypeFactory == null) {
             inferenceTypeFactory = realChecker.createInferenceATF(inferenceChecker, getRealChecker(),
                     getRealTypeFactory(), getSlotManager(), getConstraintManager());
-            this.getConstraintManager().init(inferenceTypeFactory, getRealTypeFactory());
+            this.getConstraintManager().init(inferenceTypeFactory);
             logger.finer("Created InferenceAnnotatedTypeFactory");
         }
         return inferenceTypeFactory;

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -303,7 +303,7 @@ public class InferenceMain {
         if (inferenceTypeFactory == null) {
             inferenceTypeFactory = realChecker.createInferenceATF(inferenceChecker, getRealChecker(),
                     getRealTypeFactory(), getSlotManager(), getConstraintManager());
-            this.getConstraintManager().init(inferenceTypeFactory);
+            this.getConstraintManager().init(inferenceTypeFactory, getRealTypeFactory());
             logger.finer("Created InferenceAnnotatedTypeFactory");
         }
         return inferenceTypeFactory;

--- a/src/checkers/inference/model/ConstraintManager.java
+++ b/src/checkers/inference/model/ConstraintManager.java
@@ -2,7 +2,6 @@ package checkers.inference.model;
 
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.source.SourceChecker;
-import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.VisitorState;
 import org.checkerframework.javacutil.AnnotationUtils;

--- a/src/checkers/inference/model/ConstraintManager.java
+++ b/src/checkers/inference/model/ConstraintManager.java
@@ -37,9 +37,9 @@ public class ConstraintManager {
 
     private VisitorState visitorState;
 
-    public void init(InferenceAnnotatedTypeFactory inferenceTypeFactory, AnnotatedTypeFactory realTypeFactory) {
+    public void init(InferenceAnnotatedTypeFactory inferenceTypeFactory) {
         this.inferenceTypeFactory = inferenceTypeFactory;
-        this.realQualHierarchy = realTypeFactory.getQualifierHierarchy();
+        this.realQualHierarchy = inferenceTypeFactory.getQualifierHierarchy();
         this.visitorState = inferenceTypeFactory.getVisitorState();
         this.checker = inferenceTypeFactory.getContext().getChecker();
     }

--- a/src/checkers/inference/model/ConstraintManager.java
+++ b/src/checkers/inference/model/ConstraintManager.java
@@ -39,7 +39,7 @@ public class ConstraintManager {
 
     public void init(InferenceAnnotatedTypeFactory inferenceTypeFactory) {
         this.inferenceTypeFactory = inferenceTypeFactory;
-        this.realQualHierarchy = inferenceTypeFactory.getQualifierHierarchy();
+        this.realQualHierarchy = inferenceTypeFactory.getRealQualifierHierarchy();
         this.visitorState = inferenceTypeFactory.getVisitorState();
         this.checker = inferenceTypeFactory.getContext().getChecker();
     }

--- a/src/checkers/inference/model/ConstraintManager.java
+++ b/src/checkers/inference/model/ConstraintManager.java
@@ -2,6 +2,7 @@ package checkers.inference.model;
 
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.source.SourceChecker;
+import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.VisitorState;
 import org.checkerframework.javacutil.AnnotationUtils;
@@ -32,13 +33,13 @@ public class ConstraintManager {
 
     private SourceChecker checker;
 
-    private QualifierHierarchy qualHierarchy;
+    private QualifierHierarchy realQualHierarchy;
 
     private VisitorState visitorState;
 
-    public void init(InferenceAnnotatedTypeFactory inferenceTypeFactory) {
+    public void init(InferenceAnnotatedTypeFactory inferenceTypeFactory, AnnotatedTypeFactory realTypeFactory) {
         this.inferenceTypeFactory = inferenceTypeFactory;
-        this.qualHierarchy = inferenceTypeFactory.getQualifierHierarchy();
+        this.realQualHierarchy = realTypeFactory.getQualifierHierarchy();
         this.visitorState = inferenceTypeFactory.getVisitorState();
         this.checker = inferenceTypeFactory.getContext().getChecker();
     }
@@ -70,7 +71,7 @@ public class ConstraintManager {
             ConstantSlot subConstant = (ConstantSlot) subtype;
             ConstantSlot superConstant = (ConstantSlot) supertype;
 
-            if (!qualHierarchy.isSubtype(subConstant.getValue(), superConstant.getValue())) {
+            if (!realQualHierarchy.isSubtype(subConstant.getValue(), superConstant.getValue())) {
                 checker.report(Result.failure("subtype.type.incompatible", subtype, supertype),
                         visitorState.getPath().getLeaf());
             }
@@ -118,8 +119,8 @@ public class ConstraintManager {
         if (first instanceof ConstantSlot && second instanceof ConstantSlot) {
             ConstantSlot firstConstant = (ConstantSlot) first;
             ConstantSlot secondConstant = (ConstantSlot) second;
-            if (!qualHierarchy.isSubtype(firstConstant.getValue(), secondConstant.getValue())
-                    && !qualHierarchy.isSubtype(secondConstant.getValue(), firstConstant.getValue())) {
+            if (!realQualHierarchy.isSubtype(firstConstant.getValue(), secondConstant.getValue())
+                    && !realQualHierarchy.isSubtype(secondConstant.getValue(), firstConstant.getValue())) {
                 checker.report(Result.failure("comparable.type.incompatible", first, second),
                         visitorState.getPath().getLeaf());
             }
@@ -162,10 +163,10 @@ public class ConstraintManager {
 
     public void addSubtypeConstraint(Slot subtype, Slot supertype) {
         if ((subtype instanceof ConstantSlot)
-                && this.qualHierarchy.getTopAnnotations().contains(((ConstantSlot) subtype).getValue())) {
+                && this.realQualHierarchy.getTopAnnotations().contains(((ConstantSlot) subtype).getValue())) {
             this.addEqualityConstraint(supertype, (ConstantSlot) subtype);
         } else if ((supertype instanceof ConstantSlot)
-                && this.qualHierarchy.getBottomAnnotations().contains(
+                && this.realQualHierarchy.getBottomAnnotations().contains(
                         ((ConstantSlot) supertype).getValue())) {
             this.addEqualityConstraint(subtype, (ConstantSlot) supertype);
         } else {

--- a/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
+++ b/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
@@ -320,7 +320,7 @@ public class SimpleFlowAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror getTopAnnotation(AnnotationMirror start) {
-            if (checker instanceof IFlowSinkChecker) {
+            if (start.toString().contains("Sink")) {
                 return NOSINK;
             } else {
                 return ANYSOURCE;
@@ -336,7 +336,7 @@ public class SimpleFlowAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror getBottomAnnotation(AnnotationMirror start) {
-            if (checker instanceof IFlowSinkChecker) {
+            if (start.toString().contains("Sink")) {
                 return ANYSINK;
             } else {
                 return NOSOURCE;

--- a/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
+++ b/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
@@ -328,6 +328,22 @@ public class SimpleFlowAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         @Override
+        public AnnotationMirror getBottomAnnotation(AnnotationMirror start) {
+            if (start.toString().contains("Sink")) {
+                return ANYSINK;
+            } else {
+                return NOSOURCE;
+            }
+        }
+
+        @Override
+        public Set<? extends AnnotationMirror> getBottomAnnotations() {
+            return Collections.singleton(checker instanceof IFlowSinkChecker ?
+                    ANYSINK :
+                    NOSOURCE);
+        }
+
+        @Override
         public boolean isSubtype(AnnotationMirror subtype, AnnotationMirror supertype) {
             if (isPolySourceQualifier(supertype) && isPolySourceQualifier(subtype)) {
                 return true;

--- a/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
+++ b/src/sparta/checkers/SimpleFlowAnnotatedTypeFactory.java
@@ -320,19 +320,10 @@ public class SimpleFlowAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror getTopAnnotation(AnnotationMirror start) {
-            if (start.toString().contains("Sink")) {
+            if (checker instanceof IFlowSinkChecker) {
                 return NOSINK;
             } else {
                 return ANYSOURCE;
-            }
-        }
-
-        @Override
-        public AnnotationMirror getBottomAnnotation(AnnotationMirror start) {
-            if (start.toString().contains("Sink")) {
-                return ANYSINK;
-            } else {
-                return NOSOURCE;
             }
         }
 
@@ -341,6 +332,15 @@ public class SimpleFlowAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return Collections.singleton(checker instanceof IFlowSinkChecker ?
                     ANYSINK :
                     NOSOURCE);
+        }
+
+        @Override
+        public AnnotationMirror getBottomAnnotation(AnnotationMirror start) {
+            if (checker instanceof IFlowSinkChecker) {
+                return ANYSINK;
+            } else {
+                return NOSOURCE;
+            }
         }
 
         @Override


### PR DESCRIPTION
In `ConstraintManager`, it use `qualifierHierarchy` to make some type checking (e.g. validating type relationship before adding a subtypeConstraint) and optimizations(e.g. creating EqualityConstraint instead of SubtypeConstraint when sub is top or super is bot). However, it used the `InferenceQualifierHierarchy` to check qualifier orders, which is wrong because `InferenceQualifierHierarchy` isn't for maintaining the real qualifier hierarchy.

In this PR, I changed the reference to `qualifierHierarchy` in `ConstraintManager` to be the realQualifierHierarchy. In order to achieve this, following changes has been made:

- Passed `RealTypeFactory` reference when initializing `constraintManager` in `InferenceMain`.

- Changed `qualifierHierarchy` refer to the real qualifier hierarchy in `constraintManager.

- Add two overrides in `SimpleFlowAnnotatedTypeFactory$FlowQualifierHierarchy`: #getBottomAnnotation and #getBottomAnnotations: similar to existing #getTopAnnotation(s), `FlowQualifierHierarchy` should explicitly encoding what is it's bottom annotation.