### PR TITLE
[DefaultSlotManager] Avoid caching for missing location slot.

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -61,8 +61,8 @@ public class DefaultSlotManager implements SlotManager {
     /**
      * A map of {@link AnnotationLocation} to {@link Integer} for caching
      * VariableSlot and RefinementVariableSlot. Those two kinds of slots can be
-     * uniquely identified by their {@link AnnotationLocation}. {@link Integer}
-     * is the id of the corresponding VariableSlot or RefinementVariableSlot
+     * uniquely identified by their {@link AnnotationLocation}(Except MissingLocation).
+     * {@link Integer} is the id of the corresponding VariableSlot or RefinementVariableSlot
      */
     private final Map<AnnotationLocation, Integer> locationCache;
 
@@ -285,7 +285,11 @@ public class DefaultSlotManager implements SlotManager {
     @Override
     public VariableSlot createVariableSlot(AnnotationLocation location) {
         VariableSlot variableSlot;
-        if (locationCache.containsKey(location)) {
+        if (location.getKind() == AnnotationLocation.Kind.MISSING) {
+            //Don't cache slot for MISSING LOCATION. Just create a new one and return.
+            variableSlot = new VariableSlot(location, nextId());
+            addToVariables(variableSlot);
+        } else if (locationCache.containsKey(location)) {
             int id = locationCache.get(location);
             variableSlot = getVariable(id);
         } else {
@@ -299,7 +303,11 @@ public class DefaultSlotManager implements SlotManager {
     @Override
     public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined) {
         RefinementVariableSlot refinementVariableSlot;
-        if (locationCache.containsKey(location)) {
+        if (location.getKind() == AnnotationLocation.Kind.MISSING) {
+            //Don't cache slot for MISSING LOCATION. Just create a new one and return.
+            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), refined);
+            addToVariables(refinementVariableSlot);
+        } else if (locationCache.containsKey(location)) {
             int id = locationCache.get(location);
             refinementVariableSlot = (RefinementVariableSlot) getVariable(id);
         } else {


### PR DESCRIPTION
In `DefaultSlotManager`, it caches slots that created before to avoid duplication. These slots are identified by their `AnnotationLocation`. This identity is effective except in the case of `MissingLocation`. That means, if we cache slots for `MissingLocation`, we will get a slot that mapped to all `MissingLocation`, in some cases this will cause constraints generated has problem (As they using the same slot for different `MissingLocation` to construct constraints).

This PR is a quick fix for this problem -- In `createVariableSlot` and `createRefinementSlot` method, directly create a new slot for `MissingLocation` instead of caching them.

A minimum test case testing against on `Ontology`type system show as below: (contains two files and calling a byte code method):

```java
\\First File
import ontology.qual.Ontology;
import ontology.qual.OntologyValue;
import ontology.qual.PolyOntology;

import java.util.List;
import java.util.ArrayList;

class C {
    protected @Ontology(values={OntologyValue.VELOCITY_3D}) Vector3 v;

    protected void m(Vector3 v1, Vector3 v2) {
        List<Object> list = new ArrayList<>();
        v = v1.add(
            v2.multiply(Math.abs(1))
            );
    }
}
```

```
\\Second File
public class Vector3 {
    public Vector3 add(Vector3 vector) {
        return this;
    }

    public Vector3 multiply(float number) {
        return this;
    }
}
```