### PR TITLE
Passing realATF when finding typeArgs by AnnotationTypes

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -6,7 +6,6 @@ import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
-import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
@@ -56,6 +55,7 @@ import checkers.inference.model.ConstraintManager;
 import checkers.inference.model.Slot;
 import checkers.inference.model.VariableSlot;
 import checkers.inference.qual.VarAnnot;
+import checkers.inference.typearginference.InferenceTypeArgumentInference;
 import checkers.inference.util.ConstantToVariableAnnotator;
 import checkers.inference.util.InferenceUtil;
 
@@ -425,7 +425,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         // determine substitution for method type variables
         final Map<TypeVariable, AnnotatedTypeMirror> typeVarMapping =
-                AnnotatedTypes.findTypeArguments(processingEnv, this, expressionTree, methodElement, methodType);
+                AnnotatedTypes.findTypeArguments(processingEnv, this.realTypeFactory, expressionTree, methodElement, methodType);
 
         if (typeVarMapping.isEmpty()) {
             return Pair.<AnnotatedExecutableType, List<AnnotatedTypeMirror>>of(methodType, new LinkedList<AnnotatedTypeMirror>());
@@ -584,7 +584,5 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         this.variableAnnotator.clearTreeInfo();
         super.setRoot(root);
     }
-
-
 }
 


### PR DESCRIPTION
To be honest, I don't fully understand the fix.

CFI currently will crash on below language construct:

```java
import java.util.Collections;
import java.util.List;

class EmptyEqualCons<T> {

	protected List<T> genericList;

	public List<T> getUnModifiableGenericList() {
		return Collections.unmodifiableList(this.genericList);
	}
}
```

And the stack trace is:

<pre>
INFO: error: Create equality constraint with null argument. Subtype: null Supertype: @ontology.qual.Ontology(values={ontology.qual.OntologyValue.BOTTOM})
  Compilation unit: debug/EmptyEqualCons.java
  Exception: java.lang.Throwable; Stack trace: org.checkerframework.framework.source.SourceChecker.errorAbort(SourceChecker.java:727)
  org.checkerframework.javacutil.ErrorReporter.errorAbort(ErrorReporter.java:25)
  checkers.inference.model.ConstraintManager.createEqualityConstraint(ConstraintManager.java:83)
  checkers.inference.model.ConstraintManager.addEqualityConstraint(ConstraintManager.java:177)
  checkers.inference.model.ConstraintManager.addSubtypeConstraint(ConstraintManager.java:170)
  checkers.inference.InferenceQualifierHierarchy.isSubtype(InferenceQualifierHierarchy.java:224)
  <b>org.checkerframework.framework.util.typeinference.DefaultTypeArgumentInference.clampToLowerBound(DefaultTypeArgumentInference.java:421)</b>
  org.checkerframework.framework.util.typeinference.DefaultTypeArgumentInference.infer(DefaultTypeArgumentInference.java:317)
  org.checkerframework.framework.util.typeinference.DefaultTypeArgumentInference.inferTypeArgs(DefaultTypeArgumentInference.java:139)
  org.checkerframework.framework.util.AnnotatedTypes.findTypeArguments(AnnotatedTypes.java:577)
  <b>checkers.inference.InferenceAnnotatedTypeFactory.substituteTypeArgs(InferenceAnnotatedTypeFactory.java:428)</b>
  checkers.inference.InferenceAnnotatedTypeFactory.methodFromUse(InferenceAnnotatedTypeFactory.java:362)
  org.checkerframework.framework.type.TypeFromExpressionVisitor.visitMethodInvocation(TypeFromExpressionVisitor.java:171)
  org.checkerframework.framework.type.TypeFromExpressionVisitor.visitMethodInvocation(TypeFromExpressionVisitor.java:45)
  com.sun.tools.javac.tree.JCTree$JCMethodInvocation.accept(JCTree.java:1477)
  com.sun.source.util.SimpleTreeVisitor.visit(SimpleTreeVisitor.java:54)
  org.checkerframework.framework.type.TypeFromTree.fromExpression(TypeFromTree.java:36)
  org.checkerframework.framework.type.AnnotatedTypeFactory.fromExpression(AnnotatedTypeFactory.java:1191)
  org.checkerframework.framework.type.AnnotatedTypeFactory.getAnnotatedType(AnnotatedTypeFactory.java:965)
  org.checkerframework.framework.flow.CFAbstractTransfer.getValueFromFactory(CFAbstractTransfer.java:202)
  org.checkerframework.framework.flow.CFAbstractTransfer.visitMethodInvocation(CFAbstractTransfer.java:885)
  org.checkerframework.framework.flow.CFAbstractTransfer.visitMethodInvocation(CFAbstractTransfer.java:94)
  org.checkerframework.dataflow.cfg.node.MethodInvocationNode.accept(MethodInvocationNode.java:79)
  org.checkerframework.dataflow.analysis.Analysis.callTransferFunction(Analysis.java:404)
  org.checkerframework.dataflow.analysis.Analysis.performAnalysis(Analysis.java:225)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.analyze(GenericAnnotatedTypeFactory.java:1095)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.analyze(GenericAnnotatedTypeFactory.java:1052)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.performFlowAnalysis(GenericAnnotatedTypeFactory.java:982)
  checkers.inference.InferenceAnnotatedTypeFactory.performFlowAnalysis(InferenceAnnotatedTypeFactory.java:471)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.checkAndPerformFlowAnalysis(GenericAnnotatedTypeFactory.java:1313)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.preProcessClassTree(GenericAnnotatedTypeFactory.java:223)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:281)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:160)
  com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:720)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:50)
  org.checkerframework.framework.source.SourceVisitor.visit(SourceVisitor.java:66)
  org.checkerframework.framework.source.SourceChecker.typeProcess(SourceChecker.java:960)
  org.checkerframework.common.basetype.BaseTypeChecker.typeProcess(BaseTypeChecker.java:494)
  org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:185)
  com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:681)
  com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:111)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1343)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1297)
  com.sun.tools.javac.main.JavaCompiler.compile2(JavaCompiler.java:902)
  com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:861)
  com.sun.tools.javac.main.Main.compile(Main.java:523)
  com.sun.tools.javac.main.Main.compile(Main.java:381)
  com.sun.tools.javac.main.Main.compile(Main.java:370)
  com.sun.tools.javac.main.Main.compile(Main.java:361)
  checkers.inference.CheckerFrameworkUtil.invokeCheckerFramework(CheckerFrameworkUtil.java:12)
  checkers.inference.InferenceMain.startCheckerFramework(InferenceMain.java:185)
  checkers.inference.InferenceMain.run(InferenceMain.java:143)
  checkers.inference.InferenceMain.main(InferenceMain.java:115)
</pre>

Notice the two bolded lines, In [`InferenceAnnotatedTypeFactory.substituteTypeArgs():428`](https://github.com/opprop/checker-framework-inference/blob/master/src/checkers/inference/InferenceAnnotatedTypeFactory.java#L428) it passing `this` reference into `substituteTypeArgs` call. Then follow the stack trace, later on in [`DefaultTypeArgumentInference.clampToLowerBound:421`](https://github.com/opprop/checker-framework/blob/master/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java#L421)  `qualifierHierarchy.isSubtype` is used to evaluate subtype relationships.

We know that `InferenceQualifierHierarchy#isSubtype` will generate constraints rather than evaluate subtypes, so it seems wrong to me that passing `inferenceATF` and then using `inferenceQualifierHierarchy#isSubtype` to evaluate subtypes.

Therefore, intuitively, maybe we should passing in `realATF` in line  [`InferenceAnnotatedTypeFactory.substituteTypeArgs():428`](https://github.com/opprop/checker-framework-inference/blob/master/src/checkers/inference/InferenceAnnotatedTypeFactory.java#L428)?

I've checked passed `aTypeFactory` reference used places in this calling chain, there is no `inferenceATF` overridden  methods used in passed `aTypeFactory`, so currently it is safe to replace the `inferenceATF` reference by `realATF` reference.

However, I still have some questions: @wmdietl @topnessman 

1. Can the `aTypeFactory` reference in `DefaultTypeArgumentInference` be an `inferenceATF`? In `DefaultTypeArgumentInference` there has some places that use `aTypeFactory.qualifierHierarchy#isSubtype` method to evaluate subtype relationships, which will cause problems when the `aTypeFactory` reference is an `inferenceATF`. It that means `inferenceATF` is "not compatible" with `DefaultTypeArgumentInference`?

2. I've also noticed there is an `InferenceTypeArgumentInference` implementation that seems created for `InferenceATF`. So let `inferenceATF` return an `InferenceTypeArgumentInference` instead of `DefaultTypeArgumentInference` might be another possible fix. I've tried this option but there were some other crashes happened. Also, I've noticed that currently no place in our projects use this `InferenceTypeArgumentInference` implementation. Hence, is this implementation a usable one currently? Or do we deprecate this implementation and therefore no one using it?

