### PR TITLE
Move all  dependencies (except annotated JDK) to normal classpath

### DIFF
--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -28,9 +28,7 @@ distDir="$cfiDir"/dist
 
 jdkPaths="${cfDir}"/jdk/annotated
 
-javacBuild="${langtoolsDir}"/build/classes
-
-CFBuild="${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
+CFBuild="${langtoolsDir}"/build/classes:"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
 
 CFIBuild="${cfiDir}/bin"
 
@@ -51,7 +49,7 @@ fi
 
 eval "java" \
      "-DInferenceDevelLauncher.binary=${distDir} " \
-     "-DInferenceDevelLauncher.runtime.cp=${javacBuild}:${CFBuild}:${CFIBuild}:${OtherJars} " \
+     "-DInferenceDevelLauncher.runtime.cp=${CFBuild}:${CFIBuild}:${OtherJars} " \
      "-DInferenceDevelLauncher.annotated.jdk=${jdkPaths} " \
      "-classpath ${classpath} " \
      "checkers.inference.InferenceDevelLauncher " "$@"

--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -28,13 +28,17 @@ distDir="$cfiDir"/dist
 
 jdkPaths="${cfDir}"/jdk/annotated
 
-CFBuildDirs="${langtoolsDir}"/build/classes:"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
-CFIBuildDirs="${cfiDir}/bin"
+javacBuild="${langtoolsDir}"/build/classes
+
+CFBuild="${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
+
+CFIBuild="${cfiDir}/bin"
 
 SAT4jJars="${distDir}"/org.ow2.sat4j.core-2.3.4.jar:"${distDir}"/org.ow2.sat4j.maxsat-2.3.4.jar:"${distDir}"/org.ow2.sat4j.pb-2.3.4.jar
+
 OtherJars="${distDir}"/plume.jar:"${distDir}"/annotation-file-utilities.jar:"${SAT4jJars}":"${distDir}"/gson-1.7.2.jar:"${distDir}"/json-simple-1.1.1.jar:"${distDir}"/mockito-all-1.8.4.jar
 
-classpath=${CFBuildDirs}:${CFIBuildDirs}
+classpath=${CFBuild}:${CFIBuild}
 
 # append system CLASSPATH to -classpath, so that external checker could export their
 # class files in system CLASSPATH, and let InferenceDevelLauncher append them in -classpath
@@ -47,7 +51,7 @@ fi
 
 eval "java" \
      "-DInferenceDevelLauncher.binary=${distDir} " \
-     "-DInferenceDevelLauncher.runtime.bcp=${CFBuildDirs}:${CFIBuildDirs}:${OtherJars} " \
+     "-DInferenceDevelLauncher.runtime.cp=${javacBuild}:${CFBuild}:${CFIBuild}:${OtherJars} " \
      "-DInferenceDevelLauncher.annotated.jdk=${jdkPaths} " \
      "-classpath ${classpath} " \
      "checkers.inference.InferenceDevelLauncher " "$@"

--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -21,6 +21,7 @@ ROOT=$(cd ${myDir}/../../ && pwd)
 
 langtoolsDir="$ROOT"/jsr308-langtools
 annoToolsDir="$ROOT"/annotation-tools
+stubparserDir="$ROOT"/stubparser
 cfDir="$ROOT"/checker-framework
 cfiDir="$ROOT"/checker-framework-inference
 
@@ -28,7 +29,7 @@ distDir="$cfiDir"/dist
 
 jdkPaths="${cfDir}"/jdk/annotated
 
-CFBuild="${langtoolsDir}"/build/classes:"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
+CFBuild="${langtoolsDir}"/build/classes:"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${stubparserDir}"/stubparser.jar:"${cfDir}"/framework/build:"${cfDir}"/checker/build
 
 CFIBuild="${cfiDir}/bin"
 

--- a/src/checkers/inference/InferenceDevelLauncher.java
+++ b/src/checkers/inference/InferenceDevelLauncher.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.checkerframework.javacutil.ErrorReporter;
+
 /**
  * Develop Launcher for checker-framework-inference developers.
  *
@@ -96,9 +98,13 @@ public class InferenceDevelLauncher extends InferenceLauncher {
     private static List<String> prependPathOpts(final String pathProp, final List<String> pathOpts, final String ... otherPaths) {
         final String cp = System.getProperty(pathProp);
 
+        if (cp == null) {
+            ErrorReporter.errorAbort("Expected system property " + pathProp + " is null!");
+        }
+
         final List<String> newPathOpts = new ArrayList<String>();
 
-        if (cp != null && !cp.trim().isEmpty()) {
+        if (!cp.trim().isEmpty()) {
             newPathOpts.addAll(Arrays.asList(cp.split(File.pathSeparator)));
         }
 

--- a/src/checkers/inference/InferenceDevelLauncher.java
+++ b/src/checkers/inference/InferenceDevelLauncher.java
@@ -25,7 +25,7 @@ public class InferenceDevelLauncher extends InferenceLauncher {
 
     private static final String PROP_PREFIX = "InferenceDevelLauncher";
     private static final String BINARY = PROP_PREFIX + ".binary";
-    private static final String RUNTIME_BCP = PROP_PREFIX + ".runtime.bcp";
+    private static final String RUNTIME_CP = PROP_PREFIX + ".runtime.cp";
     private static final String VERBOSE = PROP_PREFIX + ".verbose";
     private static final String ANNOTATED_JDK = PROP_PREFIX + ".annotated.jdk";
 
@@ -34,14 +34,14 @@ public class InferenceDevelLauncher extends InferenceLauncher {
     }
 
     public static void main(String [] args) {
-        final String runtimeBcp = System.getProperty( RUNTIME_BCP );
+        final String runtimeCp = System.getProperty( RUNTIME_CP );
         final String binaryDir = System.getProperty( BINARY  );
         final String verbose = System.getProperty( VERBOSE );
         final String annotatedJDK = System.getProperty( ANNOTATED_JDK );
 
         if (verbose != null && verbose.equalsIgnoreCase("TRUE")) {
             System.out.print("CheckerDevelMain:\n" +
-                    "Prepended to runtime bootclasspath: " + runtimeBcp +  "\n" +
+                    "Prepended to runtime classpath: " + runtimeCp +  "\n" +
                     "annotated jdk:              " + annotatedJDK + "\n" +
                     "Binary Dir:                 " + binaryDir     +  "\n"
             );
@@ -51,7 +51,7 @@ public class InferenceDevelLauncher extends InferenceLauncher {
                 BINARY + " must specify a binary directory in which " +
                 "checker.jar, javac.jar, etc... are usually built";
 
-        assert (runtimeBcp != null) : RUNTIME_BCP + " must specify a path entry to prepend to the Java bootclasspath when running Javac";  //TODO: Fix the assert messages
+        assert (runtimeCp != null) : RUNTIME_CP + " must specify a path entry to prepend to the Java classpath when running Javac";  //TODO: Fix the assert messages
         assert (annotatedJDK != null) : ANNOTATED_JDK + " must specify a path entry to prepend to the annotated JDK";
 
         new InferenceDevelLauncher(System.out, System.err).launch(args);
@@ -72,8 +72,8 @@ public class InferenceDevelLauncher extends InferenceLauncher {
      * return the eclipse output directory instead of jars.
      * the eclipse output directory is set by {@code InferenceDevelLauncher.RUNTIME_BCP}
      */
-    public  List<String> getInferenceRuntimeBootJars() {
-        return prependPathOpts(RUNTIME_BCP, new ArrayList<String> ());
+    public  List<String> getInferenceRuntimeJars() {
+        return prependPathOpts(RUNTIME_CP, new ArrayList<String> ());
     }
 
     @Override
@@ -98,7 +98,7 @@ public class InferenceDevelLauncher extends InferenceLauncher {
 
         final List<String> newPathOpts = new ArrayList<String>();
 
-        if (!cp.trim().isEmpty()) {
+        if (cp != null && !cp.trim().isEmpty()) {
             newPathOpts.addAll(Arrays.asList(cp.split(File.pathSeparator)));
         }
 

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -127,7 +127,7 @@ public class InferenceLauncher {
         options.addAll(Arrays.asList(javaFiles));
 
         final CheckerMain checkerMain = new CheckerMain(InferenceOptions.checkerJar, options);
-        checkerMain.addToRuntimeBootclasspath(getInferenceRuntimeBootJars());
+        checkerMain.addToRuntimeClasspath(getInferenceRuntimeJars());
 
         if (InferenceOptions.printCommands) {
             outStream.println("Running typecheck command:");
@@ -154,13 +154,12 @@ public class InferenceLauncher {
         argList.addAll(getMemoryArgs());
 
         argList.add("-classpath");
-        argList.add(System.getProperty("java.class.path"));
+        argList.add(getInferenceRuntimeClassPath());
 
         if (InferenceOptions.debug != null) {
             argList.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + InferenceOptions.debug);
         }
 
-        argList.add(getInferenceRuntimeBootclassPath());
         argList.addAll(
                 Arrays.asList(
                         "-ea", "-ea:checkers.inference...",
@@ -350,9 +349,9 @@ public class InferenceLauncher {
 
     /**
      * @return the paths to the set of jars that are needed to be placed on
-     * the bootclasspath of the process running inference
+     * the classpath of the process running inference
      */
-    protected List<String> getInferenceRuntimeBootJars() {
+    protected List<String> getInferenceRuntimeJars() {
         final File distDir = InferenceOptions.pathToThisJar.getParentFile();
         String jdkJarName = PluginUtil.getJdkJarName();
 
@@ -368,10 +367,16 @@ public class InferenceLauncher {
     }
 
     //what's used to run the compiler
-    protected String getInferenceRuntimeBootclassPath() {
-        List<String> filePaths = getInferenceRuntimeBootJars();
+    protected String getInferenceRuntimeClassPath() {
+        List<String> filePaths = getInferenceRuntimeJars();
         filePaths.add(InferenceOptions.targetclasspath);
-        return "-Xbootclasspath/p:" + PluginUtil.join(File.pathSeparator, filePaths);
+
+        String systemClasspath = System.getProperty("java.class.path");
+        if (!systemClasspath.isEmpty()) {
+            filePaths.add(systemClasspath);
+        }
+
+        return PluginUtil.join(File.pathSeparator, filePaths);
     }
 
     //what the compiler compiles against


### PR DESCRIPTION
This PR depends on https://github.com/opprop/checker-framework/pull/47 .

Also, travis test is expected to be failed even the above dependent PR get merged, due to CFI currently always failing an assertion in CF (CFAbstractValue line 73 `assert validSet()`), and this is exposed once we move CFI from bootclasspath to classpath, which enable assertion checks.

This assertion failure needs to be further investigated and we will make another PR once we have a proper solution.