### PR TITLE
Use realQual to compute LUB when both annos are not varAnnot.

### DIFF
--- a/src/checkers/inference/InferenceQualifierHierarchy.java
+++ b/src/checkers/inference/InferenceQualifierHierarchy.java
@@ -240,7 +240,7 @@ public class InferenceQualifierHierarchy extends MultiGraphQualifierHierarchy {
         //for some reason LUB compares all annotations even if they are not in the same sub-hierarchy
         if (!isVarAnnot(a1)) {
             if (!isVarAnnot(a2)) {
-                return super.leastUpperBound(a1, a2);
+                return inferenceMain.getRealTypeFactory().getQualifierHierarchy().leastUpperBound(a1, a2);
             } else {
                 return null;
             }


### PR DESCRIPTION
In `InferenceQualifierHierarchy#leastUpperBound(a1, a2)`, it delegates the LUB computation to super class when both `a1` and `a2` are nonVarAnnots.

Current implementation is mal-logiced, as in the super class it will actually using `isSubtype()` to judge the subtype relationship between `a1` and `a2`, and `isSubtype()` has been override in `InferenceQualHierarchy` to always return true if both annos passed in are nonVarAnnos. Therefore, current implementation in `inferenceQualHierarchy` actually will always return `a2` as the LUB, when `a1` and `a2` are both nonVarAnnos (due to the super class implementation first judge if `a1` is subtype of `a2`, which always returned true by `inferenceQualHierarchy`).

I think a more reasonable implementation would be delegating the computation to `realQualifierHierarchy` in the case of both `a1` and `a2` are nonVarAnnos.
