### PR TITLE
 Fix CFAbsValue assertion failure in InferenceValue.

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -156,12 +156,8 @@ public class DefaultSlotManager implements SlotManager {
         // We need to build the AnntotationBuilder each time because AnnotationBuilders are only allowed to build their annotations once
         if (slotClass.equals(VariableSlot.class) || slotClass.equals(ExistentialVariableSlot.class)
                 || slotClass.equals(RefinementVariableSlot.class) || slotClass.equals(CombVariableSlot.class)
-                || slotClass.equals(ConstantSlot.class)) {
+                || slotClass.equals(ConstantSlot.class) || slotClass.equals(ConstantSlot.class)) {
             return convertVariable((VariableSlot) slot, new AnnotationBuilder(processingEnvironment, VarAnnot.class));
-        }
-
-        if (slotClass.equals(ConstantSlot.class)) {
-            return ((ConstantSlot) slot).getValue();
         }
 
         throw new IllegalArgumentException("Slot type unrecognized( " + slot.getClass() + ") Slot=" + slot.toString() );

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -109,6 +109,8 @@ public interface SlotManager {
      * Given a slot return an annotation that represents the slot when added to an AnnotatedTypeMirror.
      * If A is the annotation returned by getAnnotation( S ) where is a slot.  Then getSlot( A ) will
      * return S (or an equivalent Slot in case of Constants ).
+     * For {@code ConstantSlot}, this method should return the {@code VariableAnnotation} that represents
+     * the underlying constant.
      * @param slot A slot to convert to an annotation
      * @return An annotation representing the slot
      */

--- a/src/checkers/inference/dataflow/InferenceValue.java
+++ b/src/checkers/inference/dataflow/InferenceValue.java
@@ -64,14 +64,16 @@ public class InferenceValue extends CFValue {
         Slot slot2 = getEffectiveSlot(other);
 
         if (slot1 instanceof ConstantSlot && slot2 instanceof ConstantSlot) {
+            AnnotationMirror anno1 = slotManager.getAnnotation(slot1);
+            AnnotationMirror anno2 = slotManager.getAnnotation(slot2);
             final AnnotationMirror
-                    lub = qualifierHierarchy.leastUpperBound(((ConstantSlot) slot1).getValue(), ((ConstantSlot) slot2).getValue());
+                    lub = qualifierHierarchy.leastUpperBound(anno1, anno2);
 
-            //keep the annotations in the Unqualified/real type system;
             return analysis.createAbstractValue(Collections.singleton(lub), getLubType(other, null));
 
         } else {
-
+            //TODO: Could we fully delegate the LUB computation responsibility to qualifierHierarchy?
+            // What is the reason of having different LUB computation between qualifierHeirarchy and here?
             VariableSlot mergeSlot = createMergeVar(slot1, slot2);
             if (InferenceMain.isHackMode(mergeSlot == null)) {
                 Set<AnnotationMirror> copiedAnnos = AnnotationUtils.createAnnotationSet();


### PR DESCRIPTION
This PR propose a fix on the assertion failure when creating a constant LUB of `InferenceValue` when performing dataflow analysis  for CFI. Related context and detail description of this problem can be found in here:

https://github.com/typetools/checker-framework-inference/pull/53

https://github.com/opprop/checker-framework/pull/48

Detail changes in this PR:

- Fix inconsistent value representation in InferenceValue.
 - Clarify SlotManger interface on what should be returned by getAnnotation() for a ConstantSlot.
 - Fix InferenceQualfierHeirarchy#leaseUpperBound() method in the case of computing two nonVarAnno slots.
 - Add both constant slots case LUB computation in InferenceQualfierHeirarchy#leaseUpperBound().

@topnessman Mier, I had a change on `DefaultSlotManager` implementation about `getAnnotation()` result on a `ConstantSlot`. I think it would be helpful if we could return the `VarAnnot` represents the `ConstantSlot` here, as in some situations we need that `VarAnnot` instead of the real qualifier. Currently we don't have a way to allow us doing this (i.e. we cannot get the `VarAnnot` from a `ConstantSlot`), and `SlotManger#getAnnotation()` seems the best place to achieve this --- as we can still get the real qualifier from a `ConstantSlot` by it's `getValue()` method, and on general level `SlotManger#getAnnotation(Slot)` returns a unified representation on all `VariableSlot`s (include `ConstantSlot`).

I still not check if this change break some existing assumptions, let's see if we pass the travis test.

P.S. once upstream update https://github.com/opprop/checker-framework-inference/pull/66 has been merged, I will try enable assertions on CF dataflow again to see if this PR fix the problem properly.