### PR TITLE
Clean up createEquivalentSlotConstraints method in VariableAnnotator.

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -514,7 +514,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             }
         } else {
             AnnotationLocation location = treeToLocation(tree);
-            variable = createEquivalentSlotConstraints(atm, tree, location);
+            variable = replaceOrCreateEquivalentVarAnno(atm, tree, location);
             final Pair<VariableSlot, Set<? extends AnnotationMirror>> varATMPair = Pair
                     .<VariableSlot, Set<? extends AnnotationMirror>> of(variable,
                     AnnotationUtils.createAnnotationSet());
@@ -558,33 +558,28 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
     }
 
     /**
-     * Create and store constraints from pre-annotated code and implicits from the underlying type system.
+     * Given an atm, replace it's real annotation from pre-annotated code and implicits from the underlying type system,
+     * by the equivalent varAnnotation, or creating a new VarAnnotation for it if doesn't have any eixiting annotaions.
      */
-    private VariableSlot createEquivalentSlotConstraints(AnnotatedTypeMirror atm, Tree tree, final AnnotationLocation location) {
+    private VariableSlot replaceOrCreateEquivalentVarAnno(AnnotatedTypeMirror atm, Tree tree, final AnnotationLocation location) {
         VariableSlot varSlot = null;
-        Slot constantSlot = null;
         AnnotationMirror realQualifier = null;
 
         // Create constraints for pre-annotated code and constant slots when the variable slot is created.
         AnnotationMirror existinVar = atm.getAnnotationInHierarchy(varAnnot);
-        if (!atm.getAnnotations().isEmpty()) {
+        if (existinVar != null) {
+            varSlot = slotManager.getVariableSlot(atm);
+        } else if (!atm.getAnnotations().isEmpty()) {
             realQualifier = atm.getAnnotationInHierarchy(realTop);
             if (realQualifier == null) {
                 atm.addAnnotation(realTop);
                 realQualifier = realTop;
             }
-
-            constantSlot = slotManager.getSlot(realQualifier);
-
+            varSlot = constantToVariableAnnotator.createConstantSlot(realQualifier);
         } else if (tree != null && realChecker.isConstant(tree) ) {
             // Considered constant by real type system
             realQualifier = realTypeFactory.getAnnotatedType(tree).getAnnotationInHierarchy(realTop);
-            constantSlot = slotManager.getSlot(realQualifier);
-        }
-
-        if (constantSlot != null) {
             varSlot = constantToVariableAnnotator.createConstantSlot(realQualifier);
-
         } else {
             varSlot = createVariable(location);
         }
@@ -1088,7 +1083,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             level ++;
 
             ASTRecord astRec = astRecord.newArrayLevel(level);
-            createEquivalentSlotConstraints(loopType, tree, new AstPathLocation(astRec));
+            replaceOrCreateEquivalentVarAnno(loopType, tree, new AstPathLocation(astRec));
         }
     }
 
@@ -1128,7 +1123,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             // Create a variable from an ASTPath
             final TreePath pathToTree = inferenceTypeFactory.getPath(topLevelTree);
             ASTRecord astRec = ASTPathUtil.getASTRecordForPath(inferenceTypeFactory, pathToTree).newArrayLevel(level);
-            createEquivalentSlotConstraints(type, tree, new AstPathLocation(astRec));
+            replaceOrCreateEquivalentVarAnno(type, tree, new AstPathLocation(astRec));
 
         } else if (!(tree.getKind() == Tree.Kind.NEW_ARRAY
                      || tree.getKind() == Tree.Kind.ARRAY_TYPE)) {
@@ -1180,7 +1175,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
                 location = AnnotationLocation.MISSING_LOCATION;
             }
 
-            createEquivalentSlotConstraints(type, tree, location);
+            replaceOrCreateEquivalentVarAnno(type, tree, location);
         }
     }
 

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -571,8 +571,8 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         } else if (!atm.getAnnotations().isEmpty()) {
             realQualifier = atm.getAnnotationInHierarchy(realTop);
             if (realQualifier == null) {
-                atm.addAnnotation(realTop);
-                realQualifier = realTop;
+                ErrorReporter.errorAbort("The annotation(s) on the given type is neither VarAnno nor real qualifier!"
+                        + "Atm is: " + atm + " annotations: " + atm.getAnnotations());
             }
             varSlot = constantToVariableAnnotator.createConstantSlot(realQualifier);
         } else if (tree != null && realChecker.isConstant(tree) ) {

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -558,14 +558,13 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
     }
 
     /**
-     * Given an atm, replace it's real annotation from pre-annotated code and implicits from the underlying type system,
-     * by the equivalent varAnnotation, or creating a new VarAnnotation for it if doesn't have any eixiting annotaions.
+     * Given an atm, replace its real annotation from pre-annotated code and implicit from the underlying type system
+     * by the equivalent varAnnotation, or creating a new VarAnnotation for it if doesn't have any existing annotations.
      */
     private VariableSlot replaceOrCreateEquivalentVarAnno(AnnotatedTypeMirror atm, Tree tree, final AnnotationLocation location) {
         VariableSlot varSlot = null;
         AnnotationMirror realQualifier = null;
 
-        // Create constraints for pre-annotated code and constant slots when the variable slot is created.
         AnnotationMirror existinVar = atm.getAnnotationInHierarchy(varAnnot);
         if (existinVar != null) {
             varSlot = slotManager.getVariableSlot(atm);


### PR DESCRIPTION
In `VariableAnnotator`, it try to create a primary VarAnnotation for each visited ATM.

During this process, it delegate the responsibility of making the `varAnnotation` consistent with pre-annotated real annotations or implicit by a method called `createEquivalentSlotConstraints()`.

In this PR I cleaned up this method.

Overview change:

- renaming: from `createEquivalentSlotConstraints()` to `replaceOrCreateEquivalentVarAnno()`. 
  - The original naming is confusing. It doesn't create any constraints, instead, it just try to create/replace the real annotations(if any) by the equivalent VarAnnos on the given ATM.

- Fixing the logic: Original logic doesn't consider the case of existing Annotations on the ATM could only have existed VarAnnos without any real Annotations. In this case, the original logic will replace the existed VarAnno by a constant VarAnno that representing TOP, which would cause a strange problem in Dataflow Type system.

Regarding the test case, since Dataflow type system currently still not be integrated into CFI, I will add it after we've done the integration. (I failed to found an equivalent test case in OsTrusted/Interning type system, sorry!)