### PR TITLE
VariableAnnotator#visitDeclared#case MEMBER_SELECT: Only visit enclosing type if it is non-null.

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -684,7 +684,8 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             // identifier.
             // Otherwise we may try to annotate the outer class for a
             // Outer.Inner static class.
-            if (((MemberSelectTree) tree).getExpression().getKind() != Tree.Kind.IDENTIFIER) {
+            if (adt.getEnclosingType() != null
+                    && ((MemberSelectTree) tree).getExpression().getKind() != Tree.Kind.IDENTIFIER) {
                 visit(adt.getEnclosingType(), ((MemberSelectTree) tree).getExpression());
             }
             addDeclarationConstraints(getOrCreateDeclBound(adt), primary);

--- a/testdata/ostrusted/MemberSelectEnclosingNull.java
+++ b/testdata/ostrusted/MemberSelectEnclosingNull.java
@@ -1,0 +1,4 @@
+// Just test for non-crashing.
+class C {
+    public java.util.Timer t = new java.util.Timer();
+}


### PR DESCRIPTION
As discussed with Prof. Dietl @wmdietl  last week, should only visit enclosing type of a memberSelect tree if the enclosing type is non-null. This is because for some memberSelect tree, it's enclosing type is null, e.g. for bellow code:

```java
class C {
    public java.util.Timer t = new java.util.Timer();
}
```

`public java.util.Timer` is also a memberSelect tree, and it's enclosing type is null.

I've add the test case into OsTrusted Type system, as this is one of the base Type system in CFI.