### PR TITLE
Don't get Boxed type before delegate to aTypeFactory to judge subtype relationship

### DIFF
--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -527,11 +527,7 @@ public class InferenceVisitor<Checker extends InferenceChecker,
         //TODO: incorrectly inferred if we do not have it
         boolean success = true;
         if (!infer || (varType.getKind() != TypeKind.TYPEVAR && valueType.getKind() != TypeKind.TYPEVAR)) {
-            if (varType.getKind() == TypeKind.DECLARED && valueType.getKind().isPrimitive()) {
-                success = atypeFactory.getTypeHierarchy().isSubtype(atypeFactory.getBoxedType((AnnotatedPrimitiveType) valueType), varType);
-            } else {
-                success = atypeFactory.getTypeHierarchy().isSubtype(valueType, varType);
-            }
+            success = atypeFactory.getTypeHierarchy().isSubtype(valueType, varType);
         }
 
         //####### Copied Code ########

--- a/testdata/ostrusted/PrimitiveTypeAssignment.java
+++ b/testdata/ostrusted/PrimitiveTypeAssignment.java
@@ -1,0 +1,9 @@
+// CF Inference should not crash on this test file.
+class C
+{
+    {
+        Byte b = 1;
+        Character c = 1;
+        Integer i = 1;
+    }
+}

--- a/testdata/ostrusted/PrimitiveTypeAssignment.java
+++ b/testdata/ostrusted/PrimitiveTypeAssignment.java
@@ -1,9 +1,7 @@
 // CF Inference should not crash on this test file.
 class C
 {
-    {
-        Byte b = 1;
-        Character c = 1;
-        Integer i = 1;
-    }
+    Byte b = 1;
+    Character c = 1;
+    Integer i = 1;
 }


### PR DESCRIPTION
In `InferenceVisitor#commonAssignmentCheck()` it will check the subtype relationship between LHS and RHS. In the case of RHS is primitive type, it will first get the boxed type of RHS, then check if the boxed type are the subtype of LHS.

This boxing is improper. E.g. for below example:

```java
Byte b = 1;
```

The boxed type of RHS would be `Integer`, which would failed the isSubtype check.

Very strange, in this case I would expect the original code will just failed the subtype check. However, actually when it internally delegate this subtype check to `DefaultTypeHierarchy` with checking two incomparable types, it will cause an ErrorAbort exception thrown from CF. The reason of why CF throw an exception instead of returning  false need to be further investigate and understanding the logic.

In this PR, for a quick fix, I just remove the special case of boxing primitive types ---- This is just what `BaseTypeVisitor` did and it works fine. Since the rest of code after this special if-check in `InferenceVisitor#commonAssigmentCheck()` are copied from `BaseTypeVisitor`, I would expected remove this special boxing would works just as same as `BaseTypeVisitor`.

 I've tried to check the commit history to see why original author intended add this special boxing, but failed to see his motivation. (There were just a TODO comment about "Refine the improper boxing", then he deleted this TODO afterwards without any changes... And also it doesn't looks like he added this special boxing for fixing some corner cases) So I just removed it.

