### PR TITLE
Always found proper ATM for an anonymous type.

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -699,8 +699,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
             if (!handleWasRawDeclaredTypes(newAdt)
                     && !parameterizedTypeTree.getTypeArguments().isEmpty()) {
-                if (TypesUtils.isAnonymous(newAdt.getUnderlyingType())
-                        && parameterizedTypeTree.getType().getKind() == Kind.IDENTIFIER) {
+                if (TypesUtils.isAnonymous(newAdt.getUnderlyingType())) {
                     // There are multiple super classes for an anonymous class
                     // if the name following new keyword specifies an interface,
                     // and the anonymous class implements that interface and

--- a/testdata/ostrusted/AnonymousProblem.java
+++ b/testdata/ostrusted/AnonymousProblem.java
@@ -4,8 +4,7 @@ public class AnonymousProblem {
 
     SimpleFileVisitor s = new SimpleFileVisitor<String>(){};
 
-    OutterI.InnerI<Object> f = new OutterI.InnerI<Object>() {
-    };
+    OutterI.InnerI<Object> f = new OutterI.InnerI<Object>() {};
 
 }
 

--- a/testdata/ostrusted/AnonymousProblem.java
+++ b/testdata/ostrusted/AnonymousProblem.java
@@ -4,4 +4,12 @@ public class AnonymousProblem {
 
     SimpleFileVisitor s = new SimpleFileVisitor<String>(){};
 
+    OutterI.InnerI<Object> f = new OutterI.InnerI<Object>() {
+    };
+
+}
+
+interface OutterI<T> {
+    public interface InnerI<T> {
+    }
 }


### PR DESCRIPTION
For anonymous type, maybe we should always try to find the proper super type ATM representing this anonymous type, instead of only find it when the type is an IDENTIFIER.

E.g. given below code, the kind of anonymous type is MEMBER_SELECT, but we still want to find a proper supertype ATM represents it.

```java
OutterI.InnerI<Object> f = new OutterI.InnerI<Object>() {
};
```

So overall, I don't see is there any harm if we always find a proper super type ATM represents an anonymous type. Am I missing some corner cases? @wmdietl @topnessman 

Thanks!