### PR TITLE
Add missing Z3 dylib environment variable in inference script.

### DIFF
--- a/scripts/inference
+++ b/scripts/inference
@@ -18,11 +18,15 @@ then
 fi
 
 distDir=$myDir"/../dist"
+
+libDir=$myDir"/../lib"
+
 classpath="$distDir"/checker.jar:"$distDir"/plume.jar:"$distDir"/checker-framework-inference.jar
 
 if [ "$external_checker_classpath" != "" ] ; then
     classpath=${classpath}:${external_checker_classpath}
 fi
 
+export DYLD_LIBRARY_PATH=${libDir}
 
 eval "java -classpath  "$classpath" checkers.inference.InferenceLauncher " "$@"


### PR DESCRIPTION
Export `DYLD_LIBRARY_PATH` environment variable in inference script, so that we can also use Z3 backend when using inference script instead of inference-dev script.