### PR TITLE
Don't use graph by default

### DIFF
--- a/src/checkers/inference/solver/SolverEngine.java
+++ b/src/checkers/inference/solver/SolverEngine.java
@@ -126,7 +126,7 @@ public class SolverEngine implements InferenceSolver {
             ErrorReporter.errorAbort("Integration of solver \"" + solverName + "\" has not been implemented yet.");
         }
 
-        this.useGraph = useGraph == null || useGraph.equals(Constants.TRUE);
+        this.useGraph = Constants.TRUE.equals(useGraph);
 
         this.solveInParallel = !solverType.equals(SolverType.LOGIQL)
                 && (solveInParallel == null || solveInParallel.equals(Constants.TRUE));


### PR DESCRIPTION
This caused error solution for PICOInfer. The reason was using graph solver. So disabling it by default. If specific type system needs graph solver, then provide it explicitly.