### PR TITLE
Fix JaifBuilder not outputting String annotation fields correctly

### DIFF
--- a/src/checkers/inference/util/JaifBuilder.java
+++ b/src/checkers/inference/util/JaifBuilder.java
@@ -123,6 +123,9 @@ public class JaifBuilder {
                 }
                 if (method.getReturnType().isArray()) {
                     result += method.getReturnType().getComponentType().getSimpleName() + "[]";
+                } else if (method.getReturnType().isPrimitive() || method.getReturnType()
+                        .getCanonicalName().contentEquals("java.lang.String")) {
+                    result += method.getReturnType().getSimpleName();
                 } else {
                     result += method.getReturnType().getCanonicalName();
                 }

--- a/src/checkers/inference/util/JaifBuilder.java
+++ b/src/checkers/inference/util/JaifBuilder.java
@@ -127,7 +127,7 @@ public class JaifBuilder {
                 if (method.getReturnType().isArray()) {
                     result += method.getReturnType().getComponentType().getSimpleName() + "[]";
                 } else if (method.getReturnType().isPrimitive() || method.getReturnType()
-                        .getCanonicalName().contentEquals("java.lang.String")) {
+                        .getCanonicalName().contentEquals(String.class.getCanonicalName())) {
                     result += method.getReturnType().getSimpleName();
                 } else {
                     result += method.getReturnType().getCanonicalName();

--- a/src/checkers/inference/util/JaifBuilder.java
+++ b/src/checkers/inference/util/JaifBuilder.java
@@ -110,6 +110,9 @@ public class JaifBuilder {
      * @return the header
      */
     private String buildAnnotationHeader(Class<? extends Annotation> annotation) {
+        // TODO: rewrite this method from scratch. We don't account for all possible cases of
+        // outputs at this moment (eg annotation-field arrays). A clean rewrite should
+        // exercise and be tested for all valid annotation field types.
         String result = "";
         String packageName = annotation.getPackage().toString();
         result += packageName + ":\n";


### PR DESCRIPTION
Annotation fields of String type were printed out as "java.lang.String" instead of the expected "String" keyword in jaif files by JaifBuilder. This PR fixes the problem.