### PR TITLE
Make VariableAnnotator subclassable

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -106,7 +106,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     protected final InferrableChecker realChecker;
     private final InferenceChecker inferenceChecker;
     protected final SlotManager slotManager;
-    private final ConstraintManager constraintManager;
+    protected final ConstraintManager constraintManager;
     private final ExistentialVariableInserter existentialInserter;
     private final BytecodeTypeAnnotator bytecodeTypeAnnotator;
     private final AnnotationMirror realTop;
@@ -143,7 +143,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         this.slotManager = slotManager;
         this.constraintManager = constraintManager;
 
-        variableAnnotator = new VariableAnnotator(this, realTypeFactory, realChecker, slotManager, constraintManager);
+        variableAnnotator = createVariableAnnotator();
         bytecodeTypeAnnotator = new BytecodeTypeAnnotator(this, realTypeFactory);
 
         varAnnot = new AnnotationBuilder(processingEnv, VarAnnot.class).build();
@@ -174,6 +174,18 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public CFTransfer createFlowTransferFunction(CFAbstractAnalysis<CFValue, CFStore, CFTransfer> analysis) {
         return realChecker.createInferenceTransferFunction((InferenceAnalysis) analysis);
+    }
+
+    /**
+     * Creates a variable annotator which adds slots and constraints. Subclasses can override this
+     * method to supply a subclass of {@link VariableAnnotator} to customize the slots and
+     * constraints generated.
+     *
+     * @return a {@link VariableAnnotator} or subclass of {@link VariableAnnotator}.
+     */
+    public VariableAnnotator createVariableAnnotator() {
+        return new VariableAnnotator(
+                this, realTypeFactory, realChecker, slotManager, constraintManager);
     }
 
     @Override

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -91,12 +91,12 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
     private static final Logger logger = Logger.getLogger(VariableAnnotator.class.getName());
 
-    private final InferenceAnnotatedTypeFactory inferenceTypeFactory;
-    private final SlotManager slotManager;
+    protected final InferenceAnnotatedTypeFactory inferenceTypeFactory;
+    protected final SlotManager slotManager;
 
     // Variable Annotator needs this to create equality constraints for pre-annotated and
     // implicit code
-    private final ConstraintManager constraintManager;
+    protected final ConstraintManager constraintManager;
 
     /**
      * Store the corresponding variable slot and annotation mirrors for each
@@ -104,7 +104,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * annotation mirror for a tree is calculated (i.e least upper bound for
      * binary tree), and the calculated result is cached in the set.
      **/
-    private final Map<Tree, Pair<VariableSlot, Set<? extends AnnotationMirror>>> treeToVarAnnoPair;
+    protected final Map<Tree, Pair<VariableSlot, Set<? extends AnnotationMirror>>> treeToVarAnnoPair;
 
     /** Store elements that have already been annotated **/
     private final Map<Element, AnnotatedTypeMirror> elementToAtm;


### PR DESCRIPTION
VariableAnnotator indirectly creates LUB constraints via invoking the inference qualifier hierarchy to create a result VarAnnot for each binary tree visit. Units Inference must be able to override this behavior in order to replace LUB constraints with arithmetic constraints.

This PR allows VariableAnnotator to be subclassable by introducing createVariableAnnotator() in InferenceATF, and lifting some of the fields in VariableAnnotator from private to protected for subclass use.