### PR TITLE
Increase visiability of context and z3BVFormatTranslator field in Z3ConstraintEncoderFactory

### DIFF
--- a/src/checkers/inference/solver/backend/z3/encoder/Z3BitVectorConstraintEncoderFactory.java
+++ b/src/checkers/inference/solver/backend/z3/encoder/Z3BitVectorConstraintEncoderFactory.java
@@ -20,8 +20,8 @@ import com.microsoft.z3.Context;
  */
 public class Z3BitVectorConstraintEncoderFactory extends AbstractConstraintEncoderFactory<BoolExpr>{
 
-    private final Context context;
-    private final Z3BitVectorFormatTranslator z3BitVectorFormatTranslator;
+    protected final Context context;
+    protected final Z3BitVectorFormatTranslator z3BitVectorFormatTranslator;
 
     public Z3BitVectorConstraintEncoderFactory(Lattice lattice, ConstraintVerifier verifier,
                                                Context context, Z3BitVectorFormatTranslator z3BitVectorFormatTranslator) {


### PR DESCRIPTION
Should increase visiability of `context` and `z3BVFormatTranslator` field from `private` to `protected`, so that subclasses of `Z3ConstraintEncoderFactory ` can use these two fields.