### PR TITLE
Do not add real top qual when adding primary varAnnot for a given type.

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -521,10 +521,6 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
         atm.replaceAnnotation(slotManager.getAnnotation(variable));
 
-        if (atm.getEffectiveAnnotationInHierarchy(realTop) == null) {
-            atm.addAnnotation(realTop);
-        }
-
         return variable;
     }
 


### PR DESCRIPTION
Now we should keep only `@VarAnno` on a type when doing inference. Therefore `variableAnnotator` should not add `@RealTop` to a type anymore.