### PR TITLE
VariableAnnotator only use createVariableSlot()

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -541,7 +541,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * the type.
      */
     public VariableSlot addImpliedPrimaryVariable(AnnotatedTypeMirror atm, final AnnotationLocation location) {
-        VariableSlot variable = slotManager.createVariableSlot(location);
+        VariableSlot variable = createVariable(location);
         atm.addAnnotation(slotManager.getAnnotation(variable));
 
         AnnotationMirror realAnno = atm.getAnnotationInHierarchy(realTop);


### PR DESCRIPTION
Fix inconsistency: always call `createVariableSlot()` instead of sometimes calling `slotmanager` directly, sometime calling `createVariableSlot()`