### PR TITLE
Make createVariable() to be protected

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -255,7 +255,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      *                actual implied tree appended to it.
      * @return A new VariableSlot corresponding to tree
      */
-    private VariableSlot createVariable(final AnnotationLocation location) {
+    protected VariableSlot createVariable(final AnnotationLocation location) {
         final VariableSlot variableSlot = slotManager
                 .createVariableSlot(location);
         return variableSlot;


### PR DESCRIPTION
So PICOInfer can override it and generate inequality constraint with
`@Bottom` when creating a normal `VariableSlot` which will be inserted back
to source code(`RefinementVariableSlot`, `CombVariableSlots` other than `VariableSlot` are allowed to be inferred to `@Bottom`)
Created this PR to leave you a discussion. This might be hacky, but worked well than any other ways I tried before, for example, changing solver encoding, or do another pass to generate inequality constraint