### PR TITLE
Shallow copy element's type to avoid side effect

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -589,7 +589,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * @see checkers.inference.VariableAnnotator#annotateElementFromStore
      */
     public void storeElementType(final Element element, final AnnotatedTypeMirror atm) {
-        elementToAtm.put(element, atm);
+        elementToAtm.put(element, atm.shallowCopy(true));
     }
 
     /**


### PR DESCRIPTION
When I develop `ImplicationConstraint`, `AnnotatedDeclaredType` which is the class bound for `ClassElement` was modified without being reassigned after the last time of assignment. I didn't find the place where this mutation happened. So do defensive shallow copy to avoid such mutation. This solved the problem.