### PR TITLE
In InferATF, passing realATF when initializing InferenceQualDefault.

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -199,7 +199,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected QualifierDefaults createQualifierDefaults() {
-        return new InferenceQualifierDefaults(elements, this);
+        return new InferenceQualifierDefaults(elements, realTypeFactory);
     }
 
     public AnnotationMirror getVarAnnot() {

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -199,7 +199,10 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected QualifierDefaults createQualifierDefaults() {
-        return new InferenceQualifierDefaults(elements, realTypeFactory);
+        // As the rawVarAnnot never make sense to be a default qualifier,
+        // therefore the InferenceQualDefault should be initialized with realATF,
+        // instead of inferATF.
+        return new InferenceQualifierDefaults(elements, this);
     }
 
     public AnnotationMirror getVarAnnot() {

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -202,7 +202,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         // As the rawVarAnnot never make sense to be a default qualifier,
         // therefore the InferenceQualDefault should be initialized with realATF,
         // instead of inferATF.
-        return new InferenceQualifierDefaults(elements, this);
+        return new InferenceQualifierDefaults(elements, realTypeFactory);
     }
 
     public AnnotationMirror getVarAnnot() {


### PR DESCRIPTION
As the raw`VarAnnot` never make sense to be a default qualifier, therefore the `InferenceQualDefault` should be initialized with `realATF`, instead of `inferATF`.