### PR TITLE
Add check on value when creating ConstantSlot.

### DIFF
--- a/src/checkers/inference/model/ConstantSlot.java
+++ b/src/checkers/inference/model/ConstantSlot.java
@@ -61,7 +61,7 @@ public class ConstantSlot extends VariableSlot {
 
     private void checkAndSetValue(AnnotationMirror value) {
         if (AnnotationUtils.areSameByClass(value, VarAnnot.class)) {
-            ErrorReporter.errorAbort("Should not create a constant slot with VarAnnot as value, but the passing value is: " + value);
+            ErrorReporter.errorAbort("Invalid attempt to create a ConstantSlot with VarAnnot as value: " + value);
         }
         this.value = value;
     }

--- a/src/checkers/inference/model/ConstantSlot.java
+++ b/src/checkers/inference/model/ConstantSlot.java
@@ -1,6 +1,9 @@
 package checkers.inference.model;
 
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.ErrorReporter;
+
+import checkers.inference.qual.VarAnnot;
 
 import javax.lang.model.element.AnnotationMirror;
 
@@ -39,7 +42,7 @@ public class ConstantSlot extends VariableSlot {
      */
     public ConstantSlot(AnnotationMirror value, AnnotationLocation location, int id) {
         super(location, id);
-        this.value = value;
+        checkAndSetValue(value);
     }
 
     /**
@@ -53,6 +56,13 @@ public class ConstantSlot extends VariableSlot {
      */
     public ConstantSlot(AnnotationMirror value, int id) {
         super(id);
+        checkAndSetValue(value);
+    }
+
+    private void checkAndSetValue(AnnotationMirror value) {
+        if (AnnotationUtils.areSameByClass(value, VarAnnot.class)) {
+            ErrorReporter.errorAbort("Should not create a constant slot with VarAnnot as value!");
+        }
         this.value = value;
     }
 

--- a/src/checkers/inference/model/ConstantSlot.java
+++ b/src/checkers/inference/model/ConstantSlot.java
@@ -61,7 +61,7 @@ public class ConstantSlot extends VariableSlot {
 
     private void checkAndSetValue(AnnotationMirror value) {
         if (AnnotationUtils.areSameByClass(value, VarAnnot.class)) {
-            ErrorReporter.errorAbort("Should not create a constant slot with VarAnnot as value!");
+            ErrorReporter.errorAbort("Should not create a constant slot with VarAnnot as value, but the passing value is: " + value);
         }
         this.value = value;
     }


### PR DESCRIPTION
it never make sense to create a `ConstantSlot` with a `VarAnnot` as its value (the `realQual` constant).

Add checks on the `value` when constructing a `ConstantSlot`, error abort if the `value` is a `VarAnnot`.