### PR TITLE
Enable JaifBuilder to fully support all annotation method return types

### DIFF
--- a/src/checkers/inference/util/JaifBuilder.java
+++ b/src/checkers/inference/util/JaifBuilder.java
@@ -112,6 +112,9 @@ public class JaifBuilder {
             // annotation return type
             return;
         }
+        // cache early to prevent infinite recursion in case there are any mutually-dependent pairs
+        // of annotations (Java forbids mutually-dependent annotations)
+        writeAnnotationHeaderCache.add(annotation);
 
         // for each supported annotation, we also create headers for any annotation classes used as
         // the return type of a method of the supported annotation
@@ -134,8 +137,6 @@ public class JaifBuilder {
         // write the header for the given annotation
         builder.append(buildAnnotationHeader(annotation))
                .append("\n");
-
-        writeAnnotationHeaderCache.add(annotation);
     }
 
     /**
@@ -158,8 +159,8 @@ public class JaifBuilder {
             sb.append("    ")
               // insert the return type
               .append(getAnnotationHeaderReturnType(method.getReturnType()))
-              // insert method name
               .append(" ")
+              // insert method name
               .append(method.getName())
               .append("\n");
         }
@@ -186,7 +187,7 @@ public class JaifBuilder {
      * each of these scenarios for the given returnType argument.
      */
     private String getAnnotationHeaderReturnType(final Class<?> returnType) {
-        // desugar array return types
+        // de-sugar array return types
         boolean isArray = returnType.isArray();
         final Class<?> actualReturnType = isArray ? returnType.getComponentType() : returnType;
 

--- a/src/checkers/inference/util/JaifBuilder.java
+++ b/src/checkers/inference/util/JaifBuilder.java
@@ -109,7 +109,8 @@ public class JaifBuilder {
 
     /**
      * Add a header for a single supported annotation mirror, and recursively adds headers for any
-     * annotations used as the return type of this annotation's methods.
+     * annotations used as the return type of this annotation's methods. The annotations used as
+     * return types must always be added as a header before the annotation using it in a method.
      */
     private void writeAnnotationHeader(Class<? extends Annotation> annotation) {
         // skip if already written


### PR DESCRIPTION
This PR rewrites `buildAnnotationHeader()` in `JaifBuilder` to fully support all annotation method return types (ie, primitives, String, Class, Enum, Annotation, and 1D arrays with a component type of one of these 5 types).

To support Annotations used as method return types within an annotation, the JaifBuilder will also output annotation headers for the return type annotation ***_before_*** the annotation that uses it as a return type. This is done recursively as well for the return type annotation.

===

All of the return types can be exercised by inserting the `Annot` annotation, defined in a file as:

```
@interface InnerRTAnnot {}

@interface ReturnTypeAnnot {
    InnerRTAnnot annot() default @InnerRTAnnot;
    InnerRTAnnot[] annots() default {};
}

enum SomeEnum {
    ENUMVAL;
}

public @interface Annot {
    boolean boo() default false;
    boolean[] booArray() default {};
    String str() default "";
    String[] strArray() default {};
    Class<?> klass() default Object.class;
    Class<?>[] klassArray() default {};
    SomeEnum enumb() default SomeEnum.ENUMVAL;
    SomeEnum[] enumbArray() default {};
    ReturnTypeAnnot annot() default @ReturnTypeAnnot;
    ReturnTypeAnnot[] annotArray() default {};
}
```

Suggestions welcomed on where to place this file in CFI so we can add a regression test somewhere. I've tested the insertion of this annotation in my own repo.