### PR TITLE
Add postContextInit() method. Add defensive check on serializeVarSlot() method.

### DIFF
--- a/src/checkers/inference/solver/backend/z3/Z3BitVectorFormatTranslator.java
+++ b/src/checkers/inference/solver/backend/z3/Z3BitVectorFormatTranslator.java
@@ -27,11 +27,11 @@ import checkers.inference.solver.frontend.Lattice;
 
 public abstract class Z3BitVectorFormatTranslator extends AbstractFormatTranslator<BitVecExpr, BoolExpr, BitVecNum> {
 
+    protected Context context;
+
     protected Optimize solver;
 
     private Map<Integer, BitVecExpr> serializedSlots;
-
-    protected Context context;
 
     protected final Z3BitVectorCodec z3BitVectorCodec;
 

--- a/src/checkers/inference/solver/backend/z3/Z3BitVectorFormatTranslator.java
+++ b/src/checkers/inference/solver/backend/z3/Z3BitVectorFormatTranslator.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 
+import org.checkerframework.javacutil.ErrorReporter;
+
 import checkers.inference.solver.backend.AbstractFormatTranslator;
 import checkers.inference.solver.backend.encoder.ConstraintEncoderFactory;
 import checkers.inference.solver.backend.z3.encoder.Z3BitVectorConstraintEncoderFactory;
@@ -25,7 +27,7 @@ import checkers.inference.solver.frontend.Lattice;
 
 public abstract class Z3BitVectorFormatTranslator extends AbstractFormatTranslator<BitVecExpr, BoolExpr, BitVecNum> {
 
-    private Optimize solver;
+    protected Optimize solver;
 
     private Map<Integer, BitVecExpr> serializedSlots;
 
@@ -42,6 +44,16 @@ public abstract class Z3BitVectorFormatTranslator extends AbstractFormatTranslat
     public final void initContext(Context context) {
         this.context = context;
         finishInitializingEncoders();
+        postInitWithContext();
+    }
+
+    /**
+     * Initialize fields that requires context.
+     * Sub-class override this method to initialize
+     * objects that require the context being initialized first.
+     */
+    protected void postInitWithContext() {
+        // Intentional empty.
     }
 
     public final void initSolver(Optimize solver) {
@@ -70,6 +82,10 @@ public abstract class Z3BitVectorFormatTranslator extends AbstractFormatTranslat
     }
 
     public BitVecExpr serializeVarSlot(VariableSlot slot) {
+        if (slot instanceof ConstantSlot) {
+            ErrorReporter.errorAbort("Attempt to serializing ConstantSlot by serializeVarSlot() method. Should use serializeConstantSlot() instead!");
+        }
+
         int slotId = slot.getId();
 
         if (serializedSlots.containsKey(slotId)) {


### PR DESCRIPTION
This PR made below changes:

- Add `postInitWithContext()` method: this method is for sub-classes to initialize objects that needs `context`. (which is laze-initialized by `initContext()` method, and not initialized yet during constructor phase).

- Improve `solver` visibility from `private` to `protected`: some cases do need add additional constraints to `solver`, (e.g. add assertion constraint "that each variable slot should not equal to bottom). Therefore I improved the visibility of `solver` to provide more flexibility for sub-classes.
Note: the side effect is this do allow sub-classes add arbitrary constraints into the solver. Maybe a
better solution would be we generated complete constraints during constraint generation phase.
However, for the example case, I currently choose to add additional assertion constraints during encoding phase. (I remember Mier has some similar situation that need to assert every varSlot should not be `Bottom`. But I don't have memory on if we settled on a all-agree solution to that case). So this is my workaround.

- Add defensive check on `serializeVarSlot()` method --- it should never serialize a constantSlot.