### PR TITLE
Decoupling constraint kinds with SlotSlotCombo.

### DIFF
--- a/src/checkers/inference/solver/backend/encoder/ConstraintEncoderCoordinator.java
+++ b/src/checkers/inference/solver/backend/encoder/ConstraintEncoderCoordinator.java
@@ -32,7 +32,7 @@ public class ConstraintEncoderCoordinator {
 
     public static <ConstraintEncodingT> ConstraintEncodingT dispatch(
             BinaryConstraint constraint, BinaryConstraintEncoder<ConstraintEncodingT> encoder) {
-        SlotSlotCombo combo = SlotSlotCombo.valueOf(constraint);
+        SlotSlotCombo combo = SlotSlotCombo.valueOf(constraint.getFirst(), constraint.getSecond());
         switch (combo) {
             case VARIABLE_VARIABLE:
                 return encoder.encodeVariable_Variable((VariableSlot) constraint.getFirst(), (VariableSlot) constraint.getSecond());
@@ -53,7 +53,7 @@ public class ConstraintEncoderCoordinator {
 
     public static <ConstraintEncodingT> ConstraintEncodingT dispatch(
             CombineConstraint constraint, CombineConstraintEncoder<ConstraintEncodingT> encoder) {
-        SlotSlotCombo combo = SlotSlotCombo.valueOf(constraint);
+        SlotSlotCombo combo = SlotSlotCombo.valueOf(constraint.getTarget(), constraint.getDeclared());
         switch (combo) {
             case VARIABLE_VARIABLE:
                 return encoder.encodeVariable_Variable(

--- a/src/checkers/inference/solver/backend/encoder/SlotSlotCombo.java
+++ b/src/checkers/inference/solver/backend/encoder/SlotSlotCombo.java
@@ -51,31 +51,7 @@ public enum SlotSlotCombo {
         this.isSndVariableSlot = isSndVariableSlot;
     }
 
-    /**
-     * Gets the {@code SlotSlotCombo} of a {@link BinaryConstraint}
-     *
-     * @param binaryConstraint {@code BinaryConstraint} whose {@code SlotSlotCombo} is analyzed
-     * @return {@code SlotSlotCombo} of the passed-in {@code binaryConstraint}
-     *
-     * @see BinaryConstraint
-     */
-    public static SlotSlotCombo valueOf(BinaryConstraint binaryConstraint) {
-        return valueOf(binaryConstraint.getFirst(), binaryConstraint.getSecond());
-    }
-
-    /**
-     * Gets the {@code SlotSlotCombo} of a {@link CombineConstraint}
-     *
-     * @param combineConstraint {@code CombineConstraint} whose {@code SlotSlotCombo} is analyzed
-     * @return {@code SlotSlotCombo} of the passed-in {@code combineConstraint}
-     *
-     * @see CombineConstraint
-     */
-    public static SlotSlotCombo valueOf(CombineConstraint combineConstraint) {
-        return valueOf(combineConstraint.getTarget(), combineConstraint.getDeclared());
-    }
-
-    private static SlotSlotCombo valueOf(Slot fst, Slot snd) {
+    public static SlotSlotCombo valueOf(Slot fst, Slot snd) {
         return map[index(fst.isVariable())][index(snd.isVariable())];
     }
 


### PR DESCRIPTION
A principle I forgot who said it: " Everything must be made as simple as possible, but not one bit simpler." 

Let's made `SlotSlotCombo` simple. It just a util class doing follow job: 

Given slot1 and slot2, return the enum value that represents the kind of Combo of these two slots.

It is the client of `SlotSlotCombo` takes the responsibility that how to use this `SlotSlotCombo` result.

Thats it. `SlotSlotCombo` does not aware of anything else.
