### PR TITLE
remove combo variable and format constraint encoder coordinator

### DIFF
--- a/src/checkers/inference/solver/backend/encoder/ConstraintEncoderCoordinator.java
+++ b/src/checkers/inference/solver/backend/encoder/ConstraintEncoderCoordinator.java
@@ -13,7 +13,8 @@ import checkers.inference.solver.backend.encoder.existential.ExistentialConstrai
 import checkers.inference.solver.backend.encoder.preference.PreferenceConstraintEncoder;
 
 /**
- * A coordinator class that has the coordinating logic how each encoder encodes its supported constraint.
+ * A coordinator class that has the coordinating logic how each encoder encodes its supported
+ * constraint.
  * <p>
  * Dispatching example: this class dispatches the encoding of {@link BinaryConstraint} to the
  * corresponding encodeXXX_YYY() method in {@link BinaryConstraintEncoder} depending on the
@@ -30,16 +31,18 @@ import checkers.inference.solver.backend.encoder.preference.PreferenceConstraint
  */
 public class ConstraintEncoderCoordinator {
 
-    public static <ConstraintEncodingT> ConstraintEncodingT dispatch(
-            BinaryConstraint constraint, BinaryConstraintEncoder<ConstraintEncodingT> encoder) {
-        SlotSlotCombo combo = SlotSlotCombo.valueOf(constraint.getFirst(), constraint.getSecond());
-        switch (combo) {
+    public static <ConstraintEncodingT> ConstraintEncodingT dispatch(BinaryConstraint constraint,
+            BinaryConstraintEncoder<ConstraintEncodingT> encoder) {
+        switch (SlotSlotCombo.valueOf(constraint.getFirst(), constraint.getSecond())) {
             case VARIABLE_VARIABLE:
-                return encoder.encodeVariable_Variable((VariableSlot) constraint.getFirst(), (VariableSlot) constraint.getSecond());
+                return encoder.encodeVariable_Variable((VariableSlot) constraint.getFirst(),
+                        (VariableSlot) constraint.getSecond());
             case VARIABLE_CONSTANT:
-                return encoder.encodeVariable_Constant((VariableSlot) constraint.getFirst(), (ConstantSlot) constraint.getSecond());
+                return encoder.encodeVariable_Constant((VariableSlot) constraint.getFirst(),
+                        (ConstantSlot) constraint.getSecond());
             case CONSTANT_VARIABLE:
-                return encoder.encodeConstant_Variable((ConstantSlot) constraint.getFirst(), (VariableSlot) constraint.getSecond());
+                return encoder.encodeConstant_Variable((ConstantSlot) constraint.getFirst(),
+                        (VariableSlot) constraint.getSecond());
             case CONSTANT_CONSTANT:
                 ErrorReporter.errorAbort("Attempting to encode a constant-constant combination "
                         + "for a binary constraint. This should be normalized to "
@@ -51,33 +54,40 @@ public class ConstraintEncoderCoordinator {
         }
     }
 
-    public static <ConstraintEncodingT> ConstraintEncodingT dispatch(
-            CombineConstraint constraint, CombineConstraintEncoder<ConstraintEncodingT> encoder) {
-        SlotSlotCombo combo = SlotSlotCombo.valueOf(constraint.getTarget(), constraint.getDeclared());
-        switch (combo) {
+    public static <ConstraintEncodingT> ConstraintEncodingT dispatch(CombineConstraint constraint,
+            CombineConstraintEncoder<ConstraintEncodingT> encoder) {
+        switch (SlotSlotCombo.valueOf(constraint.getTarget(), constraint.getDeclared())) {
             case VARIABLE_VARIABLE:
-                return encoder.encodeVariable_Variable(
-                        (VariableSlot) constraint.getTarget(), (VariableSlot) constraint.getDeclared(), (VariableSlot) constraint.getResult());
+                return encoder.encodeVariable_Variable((VariableSlot) constraint.getTarget(),
+                        (VariableSlot) constraint.getDeclared(),
+                        (VariableSlot) constraint.getResult());
             case VARIABLE_CONSTANT:
-                return encoder.encodeVariable_Constant(
-                        (VariableSlot) constraint.getTarget(), (ConstantSlot) constraint.getDeclared(), (VariableSlot) constraint.getResult());
+                return encoder.encodeVariable_Constant((VariableSlot) constraint.getTarget(),
+                        (ConstantSlot) constraint.getDeclared(),
+                        (VariableSlot) constraint.getResult());
             case CONSTANT_VARIABLE:
-                return encoder.encodeConstant_Variable(
-                        (ConstantSlot) constraint.getTarget(), (VariableSlot) constraint.getDeclared(), (VariableSlot) constraint.getResult());
+                return encoder.encodeConstant_Variable((ConstantSlot) constraint.getTarget(),
+                        (VariableSlot) constraint.getDeclared(),
+                        (VariableSlot) constraint.getResult());
             case CONSTANT_CONSTANT:
-                return encoder.encodeConstant_Constant(
-                        (ConstantSlot) constraint.getTarget(), (ConstantSlot) constraint.getDeclared(), (VariableSlot) constraint.getResult());
+                return encoder.encodeConstant_Constant((ConstantSlot) constraint.getTarget(),
+                        (ConstantSlot) constraint.getDeclared(),
+                        (VariableSlot) constraint.getResult());
             default:
                 ErrorReporter.errorAbort("Unsupported SlotSlotCombo enum.");
                 return null;
         }
     }
 
-    public static <ConstraintEncodingT> ConstraintEncodingT redirect(PreferenceConstraint constraint, PreferenceConstraintEncoder<ConstraintEncodingT> encoder) {
+    public static <ConstraintEncodingT> ConstraintEncodingT redirect(
+            PreferenceConstraint constraint,
+            PreferenceConstraintEncoder<ConstraintEncodingT> encoder) {
         return encoder.encode(constraint);
     }
 
-    public static <ConstraintEncodingT> ConstraintEncodingT redirect(ExistentialConstraint constraint, ExistentialConstraintEncoder<ConstraintEncodingT> encoder) {
+    public static <ConstraintEncodingT> ConstraintEncodingT redirect(
+            ExistentialConstraint constraint,
+            ExistentialConstraintEncoder<ConstraintEncodingT> encoder) {
         return encoder.encode(constraint);
     }
 }


### PR DESCRIPTION
quick cleanup PR:

- get rid of `SlotSlotCombo combo` variable and move the expression directly into the switch statement

- formats the constraint encoder coordinator file for 80 char / line
