### PR TITLE
Enable insertion of additional annotation headers to JAIF

### DIFF
--- a/src/checkers/inference/BaseInferrableChecker.java
+++ b/src/checkers/inference/BaseInferrableChecker.java
@@ -7,9 +7,10 @@ import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.javacutil.Pair;
-
+import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.List;
-
+import java.util.Set;
 import javax.lang.model.element.VariableElement;
 
 import checkers.inference.dataflow.InferenceAnalysis;
@@ -96,5 +97,10 @@ public abstract class BaseInferrableChecker extends InferenceChecker implements 
     @Override
     public boolean isInsertMainModOfLocalVar() {
         return false;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> additionalAnnotationsForJaifInsertion() {
+        return Collections.emptySet();
     }
 }

--- a/src/checkers/inference/BaseInferrableChecker.java
+++ b/src/checkers/inference/BaseInferrableChecker.java
@@ -100,7 +100,7 @@ public abstract class BaseInferrableChecker extends InferenceChecker implements 
     }
 
     @Override
-    public Set<Class<? extends Annotation>> additionalAnnotationsForJaifInsertion() {
+    public Set<Class<? extends Annotation>> additionalAnnotationsForJaifHeaderInsertion() {
         return Collections.emptySet();
     }
 }

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -223,6 +223,10 @@ public class InferenceMain {
                 for (Class<? extends Annotation> annotation : realTypeFactory.getSupportedTypeQualifiers()) {
                     annotationClasses.add(annotation);
                 }
+                // add any custom annotations that must also be inserted to the JAIF header, such as alias annotations 
+                for (Class<? extends Annotation> annotation : realChecker.additionalAnnotationsForJaifInsertion()) {
+                    annotationClasses.add(annotation);
+                }
             }
             for (VariableSlot slot : varSlots) {
                 if (slot.getLocation() != null && slot.isInsertable()

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -223,8 +223,8 @@ public class InferenceMain {
                 for (Class<? extends Annotation> annotation : realTypeFactory.getSupportedTypeQualifiers()) {
                     annotationClasses.add(annotation);
                 }
-                // add any custom annotations that must also be inserted to the JAIF header, such as alias annotations 
-                for (Class<? extends Annotation> annotation : realChecker.additionalAnnotationsForJaifInsertion()) {
+                // add any custom annotations that must be inserted to the JAIF header, such as alias annotations 
+                for (Class<? extends Annotation> annotation : realChecker.additionalAnnotationsForJaifHeaderInsertion()) {
                     annotationClasses.add(annotation);
                 }
             }

--- a/src/checkers/inference/InferrableChecker.java
+++ b/src/checkers/inference/InferrableChecker.java
@@ -7,9 +7,9 @@ import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.javacutil.Pair;
-
+import java.lang.annotation.Annotation;
 import java.util.List;
-
+import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.VariableElement;
 
@@ -92,4 +92,9 @@ public interface InferrableChecker {
      * @return true if should insert annotations of main modifier of local variables
      */
     boolean isInsertMainModOfLocalVar();
+
+    /**
+     * @return a set of any additional annotations that should be inserted into Jaif files.
+     */
+    Set<Class<? extends Annotation>> additionalAnnotationsForJaifInsertion();
 }

--- a/src/checkers/inference/InferrableChecker.java
+++ b/src/checkers/inference/InferrableChecker.java
@@ -94,7 +94,19 @@ public interface InferrableChecker {
     boolean isInsertMainModOfLocalVar();
 
     /**
-     * @return a set of any additional annotations that should be inserted into Jaif files.
+     * If the checker inserts alias annotations (any annotation that isn't part of the supported
+     * qualifiers set) into source code, then the class literals for these alias annotations should
+     * be returned in an override of this method.
+     *
+     * For example, in Units Checker, it is preferred to insert {@code @m}, an alias annotation,
+     * into source code instead of the corresponding internal representation annotation
+     * {@code @UnitsInternal(...)} as the alias annotation is easier to understand for users.
+     *
+     * The default implementation of this method in {@
+     * BaseInferrableChecker#additionalAnnotationsForJaifHeaderInsertion()} returns an empty set.
+     *
+     * @return a set of any additional annotations that need to be inserted as annotation headers
+     *         into Jaif files.
      */
-    Set<Class<? extends Annotation>> additionalAnnotationsForJaifInsertion();
+    Set<Class<? extends Annotation>> additionalAnnotationsForJaifHeaderInsertion();
 }


### PR DESCRIPTION
This PR enables the insertion of alias annotations into source code, by providing a mechanism for a type checker to specify a set of additional annotation classes that are inserted as annotation headers into the JAIF file. The missing annotation headers are preventing the insertion of alias annotations by AFU.

The default implementation returns and empty set. In Units inference, a set of alias annotation classes are returned.