### PR TITLE
Allow passing of cfArgs to typecheck mode

### DIFF
--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -125,6 +125,7 @@ public class InferenceLauncher {
         }
 
         options.addAll(InferenceOptions.javacOptions);
+        options.add(InferenceOptions.cfArgs);
         options.addAll(Arrays.asList(javaFiles));
 
         final CheckerMain checkerMain = new CheckerMain(InferenceOptions.checkerJar, options);

--- a/src/checkers/inference/InferenceLauncher.java
+++ b/src/checkers/inference/InferenceLauncher.java
@@ -125,7 +125,9 @@ public class InferenceLauncher {
         }
 
         options.addAll(InferenceOptions.javacOptions);
-        options.add(InferenceOptions.cfArgs);
+        if (InferenceOptions.cfArgs != null && !InferenceOptions.cfArgs.isEmpty()) {
+            options.add(InferenceOptions.cfArgs);
+        }
         options.addAll(Arrays.asList(javaFiles));
 
         final CheckerMain checkerMain = new CheckerMain(InferenceOptions.checkerJar, options);


### PR DESCRIPTION
For example, to enable use of -AprintErrorStack:

`--cfArgs="-AprintErrorStack"`

which helps to debug errors

Sample output with -AprintErrorStack

```
/home/jeff/jsr308/units-inference/bin

--- Typechecking ---

error: SourceChecker.typeProcessingStart: unexpected Throwable (RuntimeException); message: Could not load class 'units.qual.UnitsInternal' for field 'value' in annotation @org.checkerframework.framework.qual.PolymorphicQualifier(units.qual.UnitsInternal.class)
  Exception: java.lang.RuntimeException: Could not load class 'units.qual.UnitsInternal' for field 'value' in annotation @org.checkerframework.framework.qual.PolymorphicQualifier(units.qual.UnitsInternal.class); Stack trace: org.checkerframework.javacutil.ErrorReporter.errorAbort(ErrorReporter.java:51)
  org.checkerframework.javacutil.AnnotationUtils.getElementValueClass(AnnotationUtils.java:675)
  org.checkerframework.framework.util.QualifierPolymorphism.getPolymorphicQualifierTop(QualifierPolymorphism.java:177)
  org.checkerframework.framework.util.MultiGraphQualifierHierarchy$MultiGraphFactory.addQualifier(MultiGraphQualifierHierarchy.java:94)
  org.checkerframework.framework.type.AnnotatedTypeFactory.createQualifierHierarchy(AnnotatedTypeFactory.java:618)
  org.checkerframework.framework.type.AnnotatedTypeFactory.createQualifierHierarchy(AnnotatedTypeFactory.java:596)
  org.checkerframework.framework.type.AnnotatedTypeFactory.postInit(AnnotatedTypeFactory.java:481)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.postInit(GenericAnnotatedTypeFactory.java:227)
  units.UnitsAnnotatedTypeFactory.<init>(UnitsAnnotatedTypeFactory.java:45)
  units.UnitsChecker.createRealTypeFactory(UnitsChecker.java:30)
  units.UnitsChecker.createRealTypeFactory(UnitsChecker.java:14)
  checkers.inference.BaseInferrableChecker.initChecker(BaseInferrableChecker.java:41)
  units.UnitsChecker.initChecker(UnitsChecker.java:19)
  org.checkerframework.framework.source.SourceChecker.typeProcessingStart(SourceChecker.java:811)
  org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:157)
  com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:681)
  com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:111)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1342)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1296)
  com.sun.tools.javac.main.JavaCompiler.compile2(JavaCompiler.java:901)
  com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:860)
  com.sun.tools.javac.main.Main.compile(Main.java:523)
  com.sun.tools.javac.main.Main.compile(Main.java:381)
  com.sun.tools.javac.main.Main.compile(Main.java:370)
  com.sun.tools.javac.main.Main.compile(Main.java:361)
  com.sun.tools.javac.Main.compile(Main.java:56)
  com.sun.tools.javac.Main.main(Main.java:42)
  Underlying Exception: java.lang.ClassNotFoundException: units.qual.UnitsInternal; Stack trace: java.net.URLClassLoader.findClass(URLClassLoader.java:381)
  java.lang.ClassLoader.loadClass(ClassLoader.java:424)
  sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
  java.lang.ClassLoader.loadClass(ClassLoader.java:357)
  java.lang.Class.forName0(Native Method)
  java.lang.Class.forName(Class.java:348)
  org.checkerframework.javacutil.AnnotationUtils.getElementValueClass(AnnotationUtils.java:668)
  org.checkerframework.framework.util.QualifierPolymorphism.getPolymorphicQualifierTop(QualifierPolymorphism.java:177)
  org.checkerframework.framework.util.MultiGraphQualifierHierarchy$MultiGraphFactory.addQualifier(MultiGraphQualifierHierarchy.java:94)
  org.checkerframework.framework.type.AnnotatedTypeFactory.createQualifierHierarchy(AnnotatedTypeFactory.java:618)
  org.checkerframework.framework.type.AnnotatedTypeFactory.createQualifierHierarchy(AnnotatedTypeFactory.java:596)
  org.checkerframework.framework.type.AnnotatedTypeFactory.postInit(AnnotatedTypeFactory.java:481)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.postInit(GenericAnnotatedTypeFactory.java:227)
  units.UnitsAnnotatedTypeFactory.<init>(UnitsAnnotatedTypeFactory.java:45)
  units.UnitsChecker.createRealTypeFactory(UnitsChecker.java:30)
  units.UnitsChecker.createRealTypeFactory(UnitsChecker.java:14)
  checkers.inference.BaseInferrableChecker.initChecker(BaseInferrableChecker.java:41)
  units.UnitsChecker.initChecker(UnitsChecker.java:19)
  org.checkerframework.framework.source.SourceChecker.typeProcessingStart(SourceChecker.java:811)
  org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:157)
  com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:681)
  com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:111)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1342)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1296)
  com.sun.tools.javac.main.JavaCompiler.compile2(JavaCompiler.java:901)
  com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:860)
  com.sun.tools.javac.main.Main.compile(Main.java:523)
  com.sun.tools.javac.main.Main.compile(Main.java:381)
  com.sun.tools.javac.main.Main.compile(Main.java:370)
  com.sun.tools.javac.main.Main.compile(Main.java:361)
  com.sun.tools.javac.Main.compile(Main.java:56)
  com.sun.tools.javac.Main.main(Main.java:42)
1 error

--- Typechecking failed ---
```