### PR TITLE
add stats keys for SMT solver & fix typo

### DIFF
--- a/src/checkers/inference/solver/strategy/GraphSolvingStrategy.java
+++ b/src/checkers/inference/solver/strategy/GraphSolvingStrategy.java
@@ -208,7 +208,7 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         }
 
         // Till this point, there must be solution
-        StatisticRecorder.record(StatisticKey.ANNOTATOIN_SIZE, (long) solutions.size());
+        StatisticRecorder.record(StatisticKey.ANNOTATION_SIZE, (long) solutions.size());
         return new DefaultInferenceResult(solutions);
     }
 }

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -22,7 +22,7 @@ public class StatisticRecorder {
         CNF_CLAUSE_SIZE,
         LOGIQL_PREDICATE_SIZE,
         LOGIQL_DATA_SIZE,
-        ANNOTATOIN_SIZE,
+        ANNOTATION_SIZE,
 
         /* Timing Info*/
         GRAPH_GENERATION_TIME,
@@ -33,6 +33,8 @@ public class StatisticRecorder {
         SAT_SOLVING_TIME,
         LOGIQL_SERIALIZATION_TIME,
         LOGIQL_SOLVING_TIME,
+        SMT_SERIALIZATION_TIME,
+        SMT_SOLVING_TIME,
     }
 
     // Use atomic integer when back ends run in parallel.

--- a/src/dataflow/solvers/general/DataflowGraphSolvingStrategy.java
+++ b/src/dataflow/solvers/general/DataflowGraphSolvingStrategy.java
@@ -147,7 +147,7 @@ public class DataflowGraphSolvingStrategy extends GraphSolvingStrategy {
             entry.setValue(refinedDataflow);
         }
 
-        StatisticRecorder.record(StatisticKey.ANNOTATOIN_SIZE, (long) solutions.size());
+        StatisticRecorder.record(StatisticKey.ANNOTATION_SIZE, (long) solutions.size());
 
         return new DefaultInferenceResult(solutions);
     }


### PR DESCRIPTION
The new keys SMT_SERIALIZATION_TIME and SMT_SOLVING_TIME are used to track the respective times for running an external SMT solver.

Typo fix for key ANNOTATION_SIZE