### PR TITLE
Upgrade statistics mechanism

### DIFF
--- a/src/checkers/inference/solver/SolverEngine.java
+++ b/src/checkers/inference/solver/SolverEngine.java
@@ -22,7 +22,7 @@ import checkers.inference.solver.util.NameUtils;
 import checkers.inference.solver.util.PrintUtils;
 import checkers.inference.solver.util.SolverArg;
 import checkers.inference.solver.util.SolverEnvironment;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 
 /**
  * SolverEngine is the entry point of general solver framework, and it is also
@@ -133,10 +133,11 @@ public class SolverEngine implements InferenceSolver {
         }
 
         if (collectStatistics) {
-            StatisticRecorder.recordSlotsStatistics(slots);
-            StatisticRecorder.recordConstraintsStatistics(constraints);
-            PrintUtils.printStatistics(StatisticRecorder.getStatistic());
-            PrintUtils.writeStatistics(StatisticRecorder.getStatistic(), noAppend);
+            Statistics.recordSlotsStatistics(slots);
+            Statistics.recordConstraintsStatistics(constraints);
+            Map<String, Long> statistics = Statistics.getStatistics();
+            PrintUtils.printStatistics(statistics);
+            PrintUtils.writeStatistics(statistics, noAppend);
         }
 
         return inferenceResult;

--- a/src/checkers/inference/solver/SolverEngine.java
+++ b/src/checkers/inference/solver/SolverEngine.java
@@ -26,7 +26,6 @@ import checkers.inference.solver.util.PrintUtils;
 import checkers.inference.solver.util.SolverArg;
 import checkers.inference.solver.util.SolverEnvironment;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 
 /**
  * SolverEngine is the entry point of general solver framework, and it is also
@@ -190,10 +189,10 @@ public class SolverEngine implements InferenceSolver {
     private Map<String, Integer> recordSlotConstraintSize(final Collection<Slot> slots,
             final Collection<Constraint> constraints) {
 
-        // Record constraint size
-        StatisticRecorder.record(StatisticKey.CONSTRAINT_SIZE, (long) constraints.size());
-        // Record slot size
-        StatisticRecorder.record(StatisticKey.SLOTS_SIZE, (long) slots.size());
+        // Record slot & constraint size
+        StatisticRecorder.record("slots_size", slots.size());
+        StatisticRecorder.record("constraint_size", constraints.size());
+
         Map<String, Integer> modelMap = new LinkedHashMap<>();
 
         final String CONSTANT_SLOT_NAME = ConstantSlot.class.getSimpleName();

--- a/src/checkers/inference/solver/SolverEngine.java
+++ b/src/checkers/inference/solver/SolverEngine.java
@@ -1,20 +1,17 @@
 package checkers.inference.solver;
 
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
 
-import checkers.inference.InferenceResult;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.BugInCF;
 
+import checkers.inference.InferenceResult;
 import checkers.inference.InferenceSolver;
-import checkers.inference.model.ConstantSlot;
 import checkers.inference.model.Constraint;
 import checkers.inference.model.Slot;
-import checkers.inference.model.VariableSlot;
 import checkers.inference.solver.backend.SolverFactory;
 import checkers.inference.solver.backend.maxsat.MaxSatSolver;
 import checkers.inference.solver.frontend.Lattice;
@@ -136,9 +133,10 @@ public class SolverEngine implements InferenceSolver {
         }
 
         if (collectStatistics) {
-            Map<String, Integer> modelRecord = recordSlotConstraintSize(slots, constraints);
-            PrintUtils.printStatistics(StatisticRecorder.getStatistic(), modelRecord);
-            PrintUtils.writeStatistics(StatisticRecorder.getStatistic(), modelRecord, noAppend);
+            StatisticRecorder.recordSlotsStatistics(slots);
+            StatisticRecorder.recordConstraintsStatistics(constraints);
+            PrintUtils.printStatistics(StatisticRecorder.getStatistic());
+            PrintUtils.writeStatistics(StatisticRecorder.getStatistic(), noAppend);
         }
 
         return inferenceResult;
@@ -177,52 +175,4 @@ public class SolverEngine implements InferenceSolver {
     protected void sanitizeSolverEngineArgs() {
         //Intentionally empty.
     }
-
-    //TODO: Move this method to the class responsible for statistic.
-    /**
-     * Method that counts the size of each kind of constraint and slot.
-     *
-     * @param slots
-     * @param constraints
-     * @return A map between name of constraint/slot and their counts.
-     */
-    private Map<String, Integer> recordSlotConstraintSize(final Collection<Slot> slots,
-            final Collection<Constraint> constraints) {
-
-        // Record slot & constraint size
-        StatisticRecorder.record("slots_size", slots.size());
-        StatisticRecorder.record("constraint_size", constraints.size());
-
-        Map<String, Integer> modelMap = new LinkedHashMap<>();
-
-        final String CONSTANT_SLOT_NAME = ConstantSlot.class.getSimpleName();
-        final String VARIABLE_SLOT_NAME = VariableSlot.class.getSimpleName();
-        for (Slot slot : slots) {
-            if (slot instanceof ConstantSlot) {
-                if (!modelMap.containsKey(CONSTANT_SLOT_NAME)) {
-                    modelMap.put(CONSTANT_SLOT_NAME, 1);
-                } else {
-                    modelMap.put(CONSTANT_SLOT_NAME, modelMap.get(CONSTANT_SLOT_NAME) + 1);
-                }
-
-            } else if (slot instanceof VariableSlot) {
-                if (!modelMap.containsKey(VARIABLE_SLOT_NAME)) {
-                    modelMap.put(VARIABLE_SLOT_NAME, 1);
-                } else {
-                    modelMap.put(VARIABLE_SLOT_NAME, modelMap.get(VARIABLE_SLOT_NAME) + 1);
-                }
-            }
-        }
-
-        for (Constraint constraint : constraints) {
-            String simpleName = constraint.getClass().getSimpleName();
-            if (!modelMap.containsKey(simpleName)) {
-                modelMap.put(simpleName, 1);
-            } else {
-                modelMap.put(simpleName, modelMap.get(simpleName) + 1);
-            }
-        }
-        return modelMap;
-    }
-
 }

--- a/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
+++ b/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
@@ -22,7 +22,7 @@ import checkers.inference.solver.backend.maxsat.MaxSatFormatTranslator;
 import checkers.inference.solver.backend.maxsat.MaxSatSolver;
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.SolverEnvironment;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 
 /**
  * LingelingSolver is also a MaxSatSolver but it calls Lingeling SAT solver to
@@ -80,8 +80,8 @@ public class LingelingSolver extends MaxSatSolver {
         long solvingTime = solvingEnd - solvingStart;
         long serializationTime = serializationEnd - serializationStart;
 
-        StatisticRecorder.recordSingleSerializationTime(serializationTime);
-        StatisticRecorder.recordSingleSolvingTime(solvingTime);
+        Statistics.addOrIncrementEntry("sat_serialization_time(ms)", serializationTime);
+        Statistics.addOrIncrementEntry("sat_solving_time(ms)", solvingTime);
 
         return solutions;
     }
@@ -175,7 +175,7 @@ public class LingelingSolver extends MaxSatSolver {
     private void recordData() {
         int totalClauses = hardClauses.size() + softClauses.size();
         int totalVariable = variableSet.size();
-        StatisticRecorder.record("cnf_clause_size", totalClauses);
-        StatisticRecorder.record("cnf_variable_size", totalVariable);
+        Statistics.addOrIncrementEntry("cnf_clause_size", totalClauses);
+        Statistics.addOrIncrementEntry("cnf_variable_size", totalVariable);
     }
 }

--- a/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
+++ b/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
@@ -23,7 +23,6 @@ import checkers.inference.solver.backend.maxsat.MaxSatSolver;
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.SolverEnvironment;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 
 /**
  * LingelingSolver is also a MaxSatSolver but it calls Lingeling SAT solver to
@@ -176,7 +175,7 @@ public class LingelingSolver extends MaxSatSolver {
     private void recordData() {
         int totalClauses = hardClauses.size() + softClauses.size();
         int totalVariable = variableSet.size();
-        StatisticRecorder.record(StatisticKey.CNF_CLAUSE_SIZE, (long) totalClauses);
-        StatisticRecorder.record(StatisticKey.CNF_VARIABLE_SIZE, (long) totalVariable);
+        StatisticRecorder.record("cnf_clause_size", totalClauses);
+        StatisticRecorder.record("cnf_variable_size", totalVariable);
     }
 }

--- a/src/checkers/inference/solver/backend/logiql/LogiQLPredicateGenerator.java
+++ b/src/checkers/inference/solver/backend/logiql/LogiQLPredicateGenerator.java
@@ -9,7 +9,6 @@ import javax.lang.model.element.AnnotationMirror;
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.NameUtils;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 
 /**
  * LogiqlConstraintGenerator take QualifierHierarchy of current type system as
@@ -175,7 +174,7 @@ public class LogiQLPredicateGenerator {
      */
     private void writeFile(String output) {
         String[] lines = output.split("\r\n|\r|\n");
-        StatisticRecorder.record(StatisticKey.LOGIQL_PREDICATE_SIZE, (long) lines.length);
+        StatisticRecorder.record("logiql_predicate_size", lines.length);
         try {
             String writePath = path + "/logiqlEncoding" + nth + ".logic";
             PrintWriter pw = new PrintWriter(writePath);

--- a/src/checkers/inference/solver/backend/logiql/LogiQLPredicateGenerator.java
+++ b/src/checkers/inference/solver/backend/logiql/LogiQLPredicateGenerator.java
@@ -8,7 +8,7 @@ import javax.lang.model.element.AnnotationMirror;
 
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.NameUtils;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 
 /**
  * LogiqlConstraintGenerator take QualifierHierarchy of current type system as
@@ -174,7 +174,7 @@ public class LogiQLPredicateGenerator {
      */
     private void writeFile(String output) {
         String[] lines = output.split("\r\n|\r|\n");
-        StatisticRecorder.record("logiql_predicate_size", lines.length);
+        Statistics.addOrIncrementEntry("logiql_predicate_size", lines.length);
         try {
             String writePath = path + "/logiqlEncoding" + nth + ".logic";
             PrintWriter pw = new PrintWriter(writePath);

--- a/src/checkers/inference/solver/backend/logiql/LogiQLSolver.java
+++ b/src/checkers/inference/solver/backend/logiql/LogiQLSolver.java
@@ -16,7 +16,7 @@ import checkers.inference.solver.backend.Solver;
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.NameUtils;
 import checkers.inference.solver.util.SolverEnvironment;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 
 /**
  * LogiQLSolver first creates LogiQL predicates text, then calls format translator
@@ -59,7 +59,7 @@ public class LogiQLSolver extends Solver<LogiQLFormatTranslator> {
         this.serializationStart = System.currentTimeMillis();
         this.encodeAllConstraints();
         this.serializationEnd = System.currentTimeMillis();
-        StatisticRecorder.record("logiql_serialization_time",
+        Statistics.addOrIncrementEntry("logiql_serialization_time(ms)",
                 (serializationEnd - serializationStart));
         addVariables();
         addConstants();
@@ -70,7 +70,7 @@ public class LogiQLSolver extends Solver<LogiQLFormatTranslator> {
         runLogicBlox.runLogicBlox();
         this.solvingEnd = System.currentTimeMillis();
 
-        StatisticRecorder.record("logiql_solving_time", (solvingEnd - solvingStart));
+        Statistics.addOrIncrementEntry("logiql_solving_time(ms)", (solvingEnd - solvingStart));
 
         //TODO: Refactor this to let Translator take the responsiblity of decoding.
         DecodingTool DecodeTool = new DecodingTool(varSlotIds, logiqldataPath, lattice, localNth);
@@ -109,7 +109,7 @@ public class LogiQLSolver extends Solver<LogiQLFormatTranslator> {
 
     private void writeLogiQLData(String path, int nth) {
         String[] lines = logiQLText.toString().split("\r\n|\r|\n");
-        StatisticRecorder.record("logiql_data_size", lines.length);
+        Statistics.addOrIncrementEntry("logiql_data_size", lines.length);
         try {
             String writePath = path + "/data" + nth + ".logic";
             File f = new File(writePath);

--- a/src/checkers/inference/solver/backend/logiql/LogiQLSolver.java
+++ b/src/checkers/inference/solver/backend/logiql/LogiQLSolver.java
@@ -17,7 +17,6 @@ import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.NameUtils;
 import checkers.inference.solver.util.SolverEnvironment;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 
 /**
  * LogiQLSolver first creates LogiQL predicates text, then calls format translator
@@ -60,7 +59,7 @@ public class LogiQLSolver extends Solver<LogiQLFormatTranslator> {
         this.serializationStart = System.currentTimeMillis();
         this.encodeAllConstraints();
         this.serializationEnd = System.currentTimeMillis();
-        StatisticRecorder.record(StatisticKey.LOGIQL_SERIALIZATION_TIME,
+        StatisticRecorder.record("logiql_serialization_time",
                 (serializationEnd - serializationStart));
         addVariables();
         addConstants();
@@ -71,7 +70,7 @@ public class LogiQLSolver extends Solver<LogiQLFormatTranslator> {
         runLogicBlox.runLogicBlox();
         this.solvingEnd = System.currentTimeMillis();
 
-        StatisticRecorder.record(StatisticKey.LOGIQL_SOLVING_TIME, (solvingEnd - solvingStart));
+        StatisticRecorder.record("logiql_solving_time", (solvingEnd - solvingStart));
 
         //TODO: Refactor this to let Translator take the responsiblity of decoding.
         DecodingTool DecodeTool = new DecodingTool(varSlotIds, logiqldataPath, lattice, localNth);
@@ -110,7 +109,7 @@ public class LogiQLSolver extends Solver<LogiQLFormatTranslator> {
 
     private void writeLogiQLData(String path, int nth) {
         String[] lines = logiQLText.toString().split("\r\n|\r|\n");
-        StatisticRecorder.record(StatisticKey.LOGIQL_DATA_SIZE, (long) lines.length);
+        StatisticRecorder.record("logiql_data_size", lines.length);
         try {
             String writePath = path + "/data" + nth + ".logic";
             File f = new File(writePath);

--- a/src/checkers/inference/solver/backend/maxsat/MaxSatSolver.java
+++ b/src/checkers/inference/solver/backend/maxsat/MaxSatSolver.java
@@ -29,7 +29,6 @@ import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.SolverArg;
 import checkers.inference.solver.util.SolverEnvironment;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 import org.sat4j.pb.IPBSolver;
 import org.sat4j.specs.ContradictionException;
 import org.sat4j.specs.IConstr;
@@ -174,7 +173,7 @@ public class MaxSatSolver extends Solver<MaxSatFormatTranslator> {
 
         solver.newVar(totalVars);
         solver.setExpectedNumberOfClauses(totalClauses);
-        StatisticRecorder.record(StatisticKey.CNF_CLAUSE_SIZE, (long) totalClauses);
+        StatisticRecorder.record("cnf_clause_size", totalClauses);
         countVariables();
         solver.setTimeoutMs(1000000);
     }
@@ -221,7 +220,7 @@ public class MaxSatSolver extends Solver<MaxSatFormatTranslator> {
                 vars.add(i);
             }
         }
-        StatisticRecorder.record(StatisticKey.CNF_VARIABLE_SIZE, (long) vars.size());
+        StatisticRecorder.record("cnf_variable_size", vars.size());
     }
 
     protected boolean shouldOutputCNF() {

--- a/src/checkers/inference/solver/backend/maxsat/MaxSatSolver.java
+++ b/src/checkers/inference/solver/backend/maxsat/MaxSatSolver.java
@@ -28,7 +28,7 @@ import checkers.inference.solver.backend.Solver;
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.SolverArg;
 import checkers.inference.solver.util.SolverEnvironment;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 import org.sat4j.pb.IPBSolver;
 import org.sat4j.specs.ContradictionException;
 import org.sat4j.specs.IConstr;
@@ -107,8 +107,8 @@ public class MaxSatSolver extends Solver<MaxSatFormatTranslator> {
             long solvingTime = solvingEnd - solvingStart;
             long serializationTime = serializationEnd - serializationStart;
 
-            StatisticRecorder.recordSingleSerializationTime(serializationTime);
-            StatisticRecorder.recordSingleSolvingTime(solvingTime);
+            Statistics.addOrIncrementEntry("sat_serialization_time(ms)", serializationTime);
+            Statistics.addOrIncrementEntry("sat_solving_time(ms)", solvingTime);
 
             if (isSatisfiable) {
                 solutions = decode(solver.model());
@@ -173,7 +173,7 @@ public class MaxSatSolver extends Solver<MaxSatFormatTranslator> {
 
         solver.newVar(totalVars);
         solver.setExpectedNumberOfClauses(totalClauses);
-        StatisticRecorder.record("cnf_clause_size", totalClauses);
+        Statistics.addOrIncrementEntry("cnf_clause_size", totalClauses);
         countVariables();
         solver.setTimeoutMs(1000000);
     }
@@ -220,7 +220,7 @@ public class MaxSatSolver extends Solver<MaxSatFormatTranslator> {
                 vars.add(i);
             }
         }
-        StatisticRecorder.record("cnf_variable_size", vars.size());
+        Statistics.addOrIncrementEntry("cnf_variable_size", vars.size());
     }
 
     protected boolean shouldOutputCNF() {

--- a/src/checkers/inference/solver/strategy/GraphSolvingStrategy.java
+++ b/src/checkers/inference/solver/strategy/GraphSolvingStrategy.java
@@ -29,7 +29,7 @@ import checkers.inference.solver.constraintgraph.GraphBuilder;
 import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.SolverArg;
 import checkers.inference.solver.util.SolverEnvironment;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 import com.sun.tools.javac.util.Pair;
 
 /**
@@ -88,8 +88,8 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         // Merge solutions.
         InferenceResult result = mergeInferenceResults(inferenceResults);
 
-        StatisticRecorder.record("graph_generation_time", (graphBuildingEnd - graphBuildingStart));
-        StatisticRecorder.record("graph_size", constraintGraph.getIndependentPath().size());
+        Statistics.addOrIncrementEntry("graph_generation_time(ms)", (graphBuildingEnd - graphBuildingStart));
+        Statistics.addOrIncrementEntry("graph_size", constraintGraph.getIndependentPath().size());
 
         return result;
     }
@@ -155,7 +155,7 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         }
         long solvingEnd = System.currentTimeMillis();
 
-        StatisticRecorder.record("overall_parallel_solving_time", (solvingEnd - solvingStart));
+        Statistics.addOrIncrementEntry("overall_parallel_solving_time(ms)", (solvingEnd - solvingStart));
         return results;
     }
 
@@ -180,7 +180,7 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         }
         long solvingEnd = System.currentTimeMillis();
 
-        StatisticRecorder.record("overall_sequential_solving_time", (solvingEnd - solvingStart));
+        Statistics.addOrIncrementEntry("overall_sequential_solving_time(ms)", (solvingEnd - solvingStart));
         return results;
     }
 
@@ -205,7 +205,7 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         }
 
         // Till this point, there must be solution
-        StatisticRecorder.record("annotation_size", solutions.size());
+        Statistics.addOrIncrementEntry("annotation_size", solutions.size());
         return new DefaultInferenceResult(solutions);
     }
 }

--- a/src/checkers/inference/solver/strategy/GraphSolvingStrategy.java
+++ b/src/checkers/inference/solver/strategy/GraphSolvingStrategy.java
@@ -30,7 +30,6 @@ import checkers.inference.solver.frontend.Lattice;
 import checkers.inference.solver.util.SolverArg;
 import checkers.inference.solver.util.SolverEnvironment;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 import com.sun.tools.javac.util.Pair;
 
 /**
@@ -89,9 +88,8 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         // Merge solutions.
         InferenceResult result = mergeInferenceResults(inferenceResults);
 
-        //TODO: Refactor way of recording Statistics.
-        StatisticRecorder.record(StatisticKey.GRAPH_GENERATION_TIME, (graphBuildingEnd - graphBuildingStart));
-        StatisticRecorder.record(StatisticKey.GRAPH_SIZE, (long) constraintGraph.getIndependentPath().size());
+        StatisticRecorder.record("graph_generation_time", (graphBuildingEnd - graphBuildingStart));
+        StatisticRecorder.record("graph_size", constraintGraph.getIndependentPath().size());
 
         return result;
     }
@@ -157,8 +155,7 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         }
         long solvingEnd = System.currentTimeMillis();
 
-        //TODO: Refactor way of recording statistic.
-        StatisticRecorder.record(StatisticKey.OVERALL_PARALLEL_SOLVING_TIME, (solvingEnd - solvingStart));
+        StatisticRecorder.record("overall_parallel_solving_time", (solvingEnd - solvingStart));
         return results;
     }
 
@@ -182,8 +179,8 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
             }
         }
         long solvingEnd = System.currentTimeMillis();
-        //TODO: Refactor way of recording statistic.
-        StatisticRecorder.record(StatisticKey.OVERALL_SEQUENTIAL_SOLVING_TIME, (solvingEnd - solvingStart));
+
+        StatisticRecorder.record("overall_sequential_solving_time", (solvingEnd - solvingStart));
         return results;
     }
 
@@ -208,7 +205,7 @@ public class GraphSolvingStrategy extends AbstractSolvingStrategy {
         }
 
         // Till this point, there must be solution
-        StatisticRecorder.record(StatisticKey.ANNOTATOIN_SIZE, (long) solutions.size());
+        StatisticRecorder.record("annotation_size", solutions.size());
         return new DefaultInferenceResult(solutions);
     }
 }

--- a/src/checkers/inference/solver/util/PrintUtils.java
+++ b/src/checkers/inference/solver/util/PrintUtils.java
@@ -32,7 +32,6 @@ import checkers.inference.model.Serializer;
 import checkers.inference.model.SubtypeConstraint;
 import checkers.inference.model.VariableSlot;
 import checkers.inference.model.serialization.ToStringSerializer;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 
 /**
  * PrintUtils contains methods for printing and writing the solved results.
@@ -112,11 +111,6 @@ public class PrintUtils {
         System.out.println("Solutions have been written to: " + outFile.getAbsolutePath() + "\n");
     }
 
-    private static void outputStatisticText(PrintStream stream,
-            StatisticKey key, Map<StatisticKey, Long> statistic) {
-        outputStatisticText(stream, key.toString(), statistic.get(key));
-    }
-
     private static void outputStatisticText(PrintStream stream, String key,
             Long value) {
         stream.println(key.toLowerCase() + "," + value);
@@ -128,14 +122,15 @@ public class PrintUtils {
      * @param statistics
      * @param modelRecord
      */
-    private static void outputStatistics(PrintStream stream, Map<StatisticKey, Long> statistics,
-            Map<String, Integer> modelRecord) {
+    private static void outputStatistics(PrintStream stream,
+            Map<String, Long> statistics, Map<String, Integer> modelRecord) {
 
         stream.println("====================== Statistics =======================");
 
         // Basic info
-        outputStatisticText(stream, StatisticKey.SLOTS_SIZE, statistics);
-        outputStatisticText(stream, StatisticKey.CONSTRAINT_SIZE, statistics);
+        for (Map.Entry<String, Long> entry : statistics.entrySet()) {
+            outputStatisticText(stream, entry.getKey(), entry.getValue());
+        }
         for (Map.Entry<String, Integer> entry : modelRecord.entrySet()) {
             outputStatisticText(stream, entry.getKey(), entry.getValue().longValue());
         }
@@ -146,7 +141,7 @@ public class PrintUtils {
     /**
      * Print the statistics to screen.
      */
-    public static void printStatistics(Map<StatisticKey, Long> statistics,
+    public static void printStatistics(Map<String, Long> statistics,
             Map<String, Integer> modelRecord) {
         outputStatistics(System.out, statistics, modelRecord);
     }
@@ -161,7 +156,9 @@ public class PrintUtils {
      *            if set to true the file will be written over, and if set to
      *            false the file will be appended.
      */
-    public static void writeStatistics(Map<StatisticKey, Long> statistics,
+    
+    // TODO: change modelRecord to be mapping to Long?
+    public static void writeStatistics(Map<String, Long> statistics,
             Map<String, Integer> modelRecord,
             boolean noAppend) {
         File outFile = new File("statistics.txt");

--- a/src/checkers/inference/solver/util/PrintUtils.java
+++ b/src/checkers/inference/solver/util/PrintUtils.java
@@ -117,28 +117,19 @@ public class PrintUtils {
      * @param statistics
      * @param modelRecord
      */
-    private static void outputStatistics(PrintStream stream,
-            Map<String, Long> statistics, Map<String, Integer> modelRecord) {
-
+    private static void outputStatistics(PrintStream stream, Map<String, Long> statistics) {
         stream.println("====================== Statistics =======================");
-
-        // Basic info
         for (Map.Entry<String, Long> entry : statistics.entrySet()) {
             stream.println(entry.getKey() + "," + entry.getValue());
         }
-        for (Map.Entry<String, Integer> entry : modelRecord.entrySet()) {
-            stream.println(entry.getKey() + "," + entry.getValue());
-        }
-
         stream.println("=========================================================");
     }
 
     /**
      * Print the statistics to screen.
      */
-    public static void printStatistics(Map<String, Long> statistics,
-            Map<String, Integer> modelRecord) {
-        outputStatistics(System.out, statistics, modelRecord);
+    public static void printStatistics(Map<String, Long> statistics) {
+        outputStatistics(System.out, statistics);
     }
 
     /**
@@ -154,11 +145,10 @@ public class PrintUtils {
     
     // TODO: change modelRecord to be mapping to Long?
     public static void writeStatistics(Map<String, Long> statistics,
-            Map<String, Integer> modelRecord,
             boolean noAppend) {
         File outFile = new File("statistics.txt");
         try (PrintStream out = getFilePrintStream(outFile, noAppend)) {
-            outputStatistics(out, statistics, modelRecord);
+            outputStatistics(out, statistics);
         }
         System.out.println("Statistics have been written to: " + outFile.getAbsolutePath() + "\n");
     }

--- a/src/checkers/inference/solver/util/PrintUtils.java
+++ b/src/checkers/inference/solver/util/PrintUtils.java
@@ -119,7 +119,7 @@ public class PrintUtils {
     private static void outputStatistics(PrintStream stream, Map<String, Long> statistics) {
         stream.println("====================== Statistics =======================");
         for (Map.Entry<String, Long> entry : statistics.entrySet()) {
-            stream.println(entry.getKey() + ", " + entry.getValue());
+            stream.println(entry.getKey() + ": " + entry.getValue());
         }
         stream.println("=========================================================");
     }

--- a/src/checkers/inference/solver/util/PrintUtils.java
+++ b/src/checkers/inference/solver/util/PrintUtils.java
@@ -111,11 +111,6 @@ public class PrintUtils {
         System.out.println("Solutions have been written to: " + outFile.getAbsolutePath() + "\n");
     }
 
-    private static void outputStatisticText(PrintStream stream, String key,
-            Long value) {
-        stream.println(key.toLowerCase() + "," + value);
-    }
-
     /**
      * Outputs the statistics to the given stream.
      * @param stream
@@ -129,10 +124,10 @@ public class PrintUtils {
 
         // Basic info
         for (Map.Entry<String, Long> entry : statistics.entrySet()) {
-            outputStatisticText(stream, entry.getKey(), entry.getValue());
+            stream.println(entry.getKey() + "," + entry.getValue());
         }
         for (Map.Entry<String, Integer> entry : modelRecord.entrySet()) {
-            outputStatisticText(stream, entry.getKey(), entry.getValue().longValue());
+            stream.println(entry.getKey() + "," + entry.getValue());
         }
 
         stream.println("=========================================================");

--- a/src/checkers/inference/solver/util/PrintUtils.java
+++ b/src/checkers/inference/solver/util/PrintUtils.java
@@ -120,7 +120,7 @@ public class PrintUtils {
     private static void outputStatistics(PrintStream stream, Map<String, Long> statistics) {
         stream.println("====================== Statistics =======================");
         for (Map.Entry<String, Long> entry : statistics.entrySet()) {
-            stream.println(entry.getKey() + "," + entry.getValue());
+            stream.println(entry.getKey() + ", " + entry.getValue());
         }
         stream.println("=========================================================");
     }

--- a/src/checkers/inference/solver/util/PrintUtils.java
+++ b/src/checkers/inference/solver/util/PrintUtils.java
@@ -115,7 +115,6 @@ public class PrintUtils {
      * Outputs the statistics to the given stream.
      * @param stream
      * @param statistics
-     * @param modelRecord
      */
     private static void outputStatistics(PrintStream stream, Map<String, Long> statistics) {
         stream.println("====================== Statistics =======================");
@@ -137,15 +136,11 @@ public class PrintUtils {
      *
      * @param statistics
      *            a map between stats keys and their long values.
-     * @param modelRecord
      * @param noAppend
      *            if set to true the file will be written over, and if set to
      *            false the file will be appended.
      */
-    
-    // TODO: change modelRecord to be mapping to Long?
-    public static void writeStatistics(Map<String, Long> statistics,
-            boolean noAppend) {
+    public static void writeStatistics(Map<String, Long> statistics, boolean noAppend) {
         File outFile = new File("statistics.txt");
         try (PrintStream out = getFilePrintStream(outFile, noAppend)) {
             outputStatistics(out, statistics);

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -22,7 +22,7 @@ public class StatisticRecorder {
     // Use atomic integer when back ends run in parallel.
     public final static AtomicInteger satSerializationTime = new AtomicInteger(0);
     public final static AtomicInteger satSolvingTime = new AtomicInteger(0);
-    // statistics are sorted alphabetically by key name
+    // statistics are sorted by insertion order
     private final static Map<String, Long> statistic = new LinkedHashMap<>();
 
     public static synchronized void recordSingleSerializationTime(long value) {
@@ -37,11 +37,9 @@ public class StatisticRecorder {
      * Adds the given value to the statistics for the given key. If an existing value exists for the
      * given key, this method stores the sum of the new value and the existing value into the key.
      *
-     * @param key
-     *            a statistic key. The key is treated case-insensitive: it will always be considered
+     * @param key a statistic key. The key is treated case-insensitive: it will always be considered
      *            in terms of its lower case equivalent.
-     * @param value
-     *            a value
+     * @param value a value
      */
     public static void record(String key, long value) {
         synchronized (statistic) {
@@ -66,10 +64,8 @@ public class StatisticRecorder {
      *
      * @see #record(String, long)
      *
-     * @param key
-     *            a statistic key
-     * @param value
-     *            a value
+     * @param key a statistic key
+     * @param value a value
      */
     public static void record(String key, int value) {
         record(key, (long) value);
@@ -86,13 +82,11 @@ public class StatisticRecorder {
 
         // Record slot counts
         Map<Class<? extends Slot>, Long> slotCounts = new LinkedHashMap<>();
-        long totalConstantSlots = 0;
+        // Total number of non-constant slots
         long totalVariableSlots = 0;
 
         for (Slot slot : slots) {
-            if (slot instanceof ConstantSlot) {
-                totalConstantSlots++;
-            } else if (slot instanceof VariableSlot) {
+            if (slot instanceof VariableSlot && !(slot instanceof ConstantSlot)) {
                 totalVariableSlots++;
             }
 
@@ -105,7 +99,6 @@ public class StatisticRecorder {
             }
         }
 
-        record("total_constant_slots", totalConstantSlots);
         record("total_variable_slots", totalVariableSlots);
 
         for (Entry<Class<? extends Slot>, Long> entry : slotCounts.entrySet()) {

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -1,9 +1,17 @@
 package checkers.inference.solver.util;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import checkers.inference.model.ConstantSlot;
+import checkers.inference.model.Constraint;
+import checkers.inference.model.Slot;
+import checkers.inference.model.VariableSlot;
 
 /**
  * Recorder for statistics.
@@ -54,9 +62,9 @@ public class StatisticRecorder {
 
     /**
      * Adds the given value to the statistics for the given key.
-     * 
+     *
      * This is a convenience method to eliminate the need to cast the value to long at call sites.
-     * 
+     *
      * @see #record(String, long)
      *
      * @param key
@@ -66,6 +74,71 @@ public class StatisticRecorder {
      */
     public static void record(String key, int value) {
         record(key, (long) value);
+    }
+
+    /**
+     * Adds a count of each kind of slot to the statistics.
+     *
+     * @param slots
+     */
+    public static void recordSlotsStatistics(final Collection<Slot> slots) {
+        // Record total number of slots
+        record("total_slots", slots.size());
+
+        // Record slot counts
+        Map<Class<? extends Slot>, Long> slotCounts = new LinkedHashMap<>();
+        long totalConstantSlots = 0;
+        long totalVariableSlots = 0;
+
+        for (Slot slot : slots) {
+            if (slot instanceof ConstantSlot) {
+                totalConstantSlots++;
+            } else if (slot instanceof VariableSlot) {
+                totalVariableSlots++;
+            }
+
+            Class<? extends Slot> slotClass = slot.getClass();
+
+            if (!slotCounts.containsKey(slotClass)) {
+                slotCounts.put(slotClass, 1L);
+            } else {
+                slotCounts.put(slotClass, slotCounts.get(slotClass) + 1L);
+            }
+        }
+
+        record("total_constant_slots", totalConstantSlots);
+        record("total_variable_slots", totalVariableSlots);
+
+        for (Entry<Class<? extends Slot>, Long> entry : slotCounts.entrySet()) {
+            record(entry.getKey().getSimpleName(), entry.getValue());
+        }
+    }
+
+    /**
+     * Adds a count of each kind of constraint to the statistics.
+     *
+     * @param constraints
+     */
+    public static void recordConstraintsStatistics(final Collection<Constraint> constraints) {
+        // Record total number of constraints
+        record("total_constraints", constraints.size());
+
+        // Record constraint counts
+        Map<Class<? extends Constraint>, Long> constraintCounts = new LinkedHashMap<>();
+
+        for (Constraint constraint : constraints) {
+            Class<? extends Constraint> constraintClass = constraint.getClass();
+
+            if (!constraintCounts.containsKey(constraintClass)) {
+                constraintCounts.put(constraintClass, 1L);
+            } else {
+                constraintCounts.put(constraintClass, constraintCounts.get(constraintClass) + 1L);
+            }
+        }
+
+        for (Entry<Class<? extends Constraint>, Long> entry : constraintCounts.entrySet()) {
+            record(entry.getKey().getSimpleName(), entry.getValue());
+        }
     }
 
     /**

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -65,6 +65,11 @@ public class StatisticRecorder {
         record(key, (long) value);
     }
 
+    /**
+     * Returns an immutable map of the collected statistics.
+     *
+     * @return the immutable map.
+     */
     public static Map<String, Long> getStatistic() {
         return Collections.unmodifiableMap(statistic);
     }

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import checkers.inference.model.ConstantSlot;
@@ -24,7 +23,7 @@ public class StatisticRecorder {
     public final static AtomicInteger satSerializationTime = new AtomicInteger(0);
     public final static AtomicInteger satSolvingTime = new AtomicInteger(0);
     // statistics are sorted alphabetically by key name
-    private final static Map<String, Long> statistic = new TreeMap<>();
+    private final static Map<String, Long> statistic = new LinkedHashMap<>();
 
     public static synchronized void recordSingleSerializationTime(long value) {
         satSerializationTime.addAndGet((int) value);

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -38,7 +38,7 @@ public class StatisticRecorder {
      * given key, this method stores the sum of the new value and the existing value into the key.
      *
      * @param key a statistic key. The key is treated case-insensitive: it will always be considered
-     *            in terms of its lower case equivalent.
+     *            in terms of its lower-case equivalent.
      * @param value a value
      */
     public static void record(String key, long value) {

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -27,19 +27,21 @@ public class StatisticRecorder {
     }
 
     /**
-     * Adds the given value to the statistics for the given key. If an existing
-     * value exists for the given key, this method stores the sum of the new
-     * value and the existing value into the key.
+     * Adds the given value to the statistics for the given key. If an existing value exists for the
+     * given key, this method stores the sum of the new value and the existing value into the key.
      *
-     * @param key a statistic key
-     * @param value a value
+     * @param key
+     *            a statistic key. The key is treated case-insensitive: it will always be considered
+     *            in terms of its lower case equivalent.
+     * @param value
+     *            a value
      */
     public static void record(String key, long value) {
         synchronized (statistic) {
+            // always use the lower-case version of the given key
             key = key.toLowerCase();
 
-            if (statistic.get(key) == null
-                    || key.contentEquals("logiql_predicate_size")) {
+            if (statistic.get(key) == null || key.contentEquals("logiql_predicate_size")) {
                 // LogiQL predicate size are fixed for same underlining type
                 // system.
                 statistic.put(key, value);
@@ -53,13 +55,14 @@ public class StatisticRecorder {
     /**
      * Adds the given value to the statistics for the given key.
      * 
-     * This is a convenience method to eliminate the need to cast the value to
-     * long at call sites.
+     * This is a convenience method to eliminate the need to cast the value to long at call sites.
      * 
      * @see #record(String, long)
      *
-     * @param key a statistic key
-     * @param value a value
+     * @param key
+     *            a statistic key
+     * @param value
+     *            a value
      */
     public static void record(String key, int value) {
         record(key, (long) value);

--- a/src/checkers/inference/solver/util/StatisticRecorder.java
+++ b/src/checkers/inference/solver/util/StatisticRecorder.java
@@ -23,7 +23,7 @@ public class StatisticRecorder {
     public final static AtomicInteger satSerializationTime = new AtomicInteger(0);
     public final static AtomicInteger satSolvingTime = new AtomicInteger(0);
     // statistics are sorted by insertion order
-    private final static Map<String, Long> statistic = new LinkedHashMap<>();
+    private final static Map<String, Long> statistics = new LinkedHashMap<>();
 
     public static synchronized void recordSingleSerializationTime(long value) {
         satSerializationTime.addAndGet((int) value);
@@ -42,17 +42,17 @@ public class StatisticRecorder {
      * @param value a value
      */
     public static void record(String key, long value) {
-        synchronized (statistic) {
+        synchronized (statistics) {
             // always use the lower-case version of the given key
             key = key.toLowerCase();
 
-            if (statistic.get(key) == null || key.contentEquals("logiql_predicate_size")) {
+            if (statistics.get(key) == null || key.contentEquals("logiql_predicate_size")) {
                 // LogiQL predicate size are fixed for same underlining type
                 // system.
-                statistic.put(key, value);
+                statistics.put(key, value);
             } else {
-                long oldValue = statistic.get(key);
-                statistic.put(key, value + oldValue);
+                long oldValue = statistics.get(key);
+                statistics.put(key, value + oldValue);
             }
         }
     }
@@ -139,6 +139,6 @@ public class StatisticRecorder {
      * @return the immutable map.
      */
     public static Map<String, Long> getStatistic() {
-        return Collections.unmodifiableMap(statistic);
+        return Collections.unmodifiableMap(statistics);
     }
 }

--- a/src/dataflow/solvers/general/DataflowGraphSolvingStrategy.java
+++ b/src/dataflow/solvers/general/DataflowGraphSolvingStrategy.java
@@ -32,7 +32,6 @@ import checkers.inference.solver.strategy.GraphSolvingStrategy;
 import checkers.inference.solver.util.PrintUtils;
 import checkers.inference.solver.util.SolverEnvironment;
 import checkers.inference.solver.util.StatisticRecorder;
-import checkers.inference.solver.util.StatisticRecorder.StatisticKey;
 import dataflow.DataflowAnnotatedTypeFactory;
 import dataflow.qual.DataFlow;
 import dataflow.qual.DataFlowInferenceBottom;
@@ -62,9 +61,7 @@ public class DataflowGraphSolvingStrategy extends GraphSolvingStrategy {
                 DataFlowInferenceBottom.class);
 
         List<Solver<?>> solvers = new ArrayList<>();
-        //TODO: Refactor statistic part.
-        StatisticRecorder.record(StatisticKey.GRAPH_SIZE, (long) constraintGraph.getConstantPath()
-                .size());
+        StatisticRecorder.record("graph_size", constraintGraph.getConstantPath().size());
 
         for (Map.Entry<Vertex, Set<Constraint>> entry : constraintGraph.getConstantPath().entrySet()) {
             AnnotationMirror anno = entry.getKey().getValue();
@@ -147,7 +144,7 @@ public class DataflowGraphSolvingStrategy extends GraphSolvingStrategy {
             entry.setValue(refinedDataflow);
         }
 
-        StatisticRecorder.record(StatisticKey.ANNOTATOIN_SIZE, (long) solutions.size());
+        StatisticRecorder.record("annotation_size", solutions.size());
 
         return new DefaultInferenceResult(solutions);
     }

--- a/src/dataflow/solvers/general/DataflowGraphSolvingStrategy.java
+++ b/src/dataflow/solvers/general/DataflowGraphSolvingStrategy.java
@@ -31,7 +31,7 @@ import checkers.inference.solver.frontend.TwoQualifiersLattice;
 import checkers.inference.solver.strategy.GraphSolvingStrategy;
 import checkers.inference.solver.util.PrintUtils;
 import checkers.inference.solver.util.SolverEnvironment;
-import checkers.inference.solver.util.StatisticRecorder;
+import checkers.inference.solver.util.Statistics;
 import dataflow.DataflowAnnotatedTypeFactory;
 import dataflow.qual.DataFlow;
 import dataflow.qual.DataFlowInferenceBottom;
@@ -61,7 +61,7 @@ public class DataflowGraphSolvingStrategy extends GraphSolvingStrategy {
                 DataFlowInferenceBottom.class);
 
         List<Solver<?>> solvers = new ArrayList<>();
-        StatisticRecorder.record("graph_size", constraintGraph.getConstantPath().size());
+        Statistics.addOrIncrementEntry("graph_size", constraintGraph.getConstantPath().size());
 
         for (Map.Entry<Vertex, Set<Constraint>> entry : constraintGraph.getConstantPath().entrySet()) {
             AnnotationMirror anno = entry.getKey().getValue();
@@ -144,7 +144,7 @@ public class DataflowGraphSolvingStrategy extends GraphSolvingStrategy {
             entry.setValue(refinedDataflow);
         }
 
-        StatisticRecorder.record("annotation_size", solutions.size());
+        Statistics.addOrIncrementEntry("annotation_size", solutions.size());
 
         return new DefaultInferenceResult(solutions);
     }

--- a/tests/checkers/system/StatisticsMultithreadTest.java
+++ b/tests/checkers/system/StatisticsMultithreadTest.java
@@ -1,0 +1,100 @@
+package checkers.system;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import checkers.inference.solver.util.Statistics;
+import junit.framework.TestCase;
+
+public class StatisticsMultithreadTest extends TestCase {
+
+    public static final int Max_Threads = 100;
+    public static final int Threads = 100;
+
+    private ExecutorService executor;
+
+    @Override
+    protected void setUp() throws Exception {
+        executor = Executors.newFixedThreadPool(Max_Threads);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        System.out.println("Statistics collected:");
+        for (Entry<String, Long> entry : Statistics.getStatistics().entrySet()) {
+            System.out.println(entry.getKey() + " --> " + entry.getValue());
+        }
+        Statistics.clearStatistics();
+        executor = null;
+    }
+
+    /**
+     * lambda interface for creating threads
+     * 
+     * each thread is given a unique threadID and the return object must implement {@link Runnable}
+     * 
+     * @param <Runnable>
+     */
+    @SuppressWarnings("hiding")
+    private interface ThreadMaker<Runnable> {
+        Runnable make(int threadID);
+    }
+
+    /**
+     * Helper which runs a number of threads and waits until all threads have completed.
+     * 
+     * @param threadMaker
+     *            lambda parameter for fresh Runnable objects
+     */
+    private void runThreads(ThreadMaker<Runnable> threadMaker) {
+        // create and execute 100 threads, each trying to add or update an entry to the statistics
+        for (int threadID = 0; threadID < Threads; threadID++) {
+            executor.execute(threadMaker.make(threadID));
+        }
+        // initiate clean shutdown of executor
+        executor.shutdown();
+        // wait for all threads to finish, up to 1 min
+        try {
+            executor.awaitTermination(1, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        // System.out.println("Finished all threads.");
+    }
+
+    // =======================================
+
+    // must be lower case for retrieval
+    public static final String IncrementEntryKey = "incremententrykey";
+    public static final long IncrementEntryVal = 100L;
+
+    @Test
+    public void testAddOrIncrementEntry() {
+        runThreads(threadID -> new AddOrIncrementEntryTestThread());
+
+        // check that the entry in the statistics match the expected value
+        Map<String, Long> finalStatistics = Statistics.getStatistics();
+        assertEquals(finalStatistics.get(IncrementEntryKey).longValue(),
+                IncrementEntryVal * Threads);
+    }
+
+    private class AddOrIncrementEntryTestThread implements Runnable {
+        @Override
+        public void run() {
+            Statistics.addOrIncrementEntry(IncrementEntryKey, IncrementEntryVal);
+        }
+    }
+
+    // =======================================
+
+    // recordSlotsStatistics
+
+    // recordConstraintsStatistics
+
+}

--- a/tests/checkers/system/StatisticsMultithreadTest.java
+++ b/tests/checkers/system/StatisticsMultithreadTest.java
@@ -39,14 +39,12 @@ public class StatisticsMultithreadTest extends TestCase {
     }
 
     /**
-     * lambda interface for creating threads
+     * Functional interface for creating threads.
      *
-     * each thread is given a unique threadID and the return object must implement {@link Runnable}
-     *
-     * @param <Runnable>
+     * Each thread is given a unique threadID and the return object must implement {@link Runnable}.
      */
-    @SuppressWarnings("hiding")
-    private interface ThreadMaker<Runnable> {
+    @FunctionalInterface
+    private interface ThreadMaker {
         Runnable make(int threadID);
     }
 
@@ -57,7 +55,7 @@ public class StatisticsMultithreadTest extends TestCase {
      * @param threadMaker
      *            lambda parameter which should return newly created threads
      */
-    private void runThreads(ThreadMaker<Runnable> threadMaker) {
+    private void runThreads(ThreadMaker threadMaker) {
         // create and execute 100 threads, each trying to add or update an entry to the statistics
         for (int threadID = 0; threadID < numOfThreads; threadID++) {
             executor.execute(threadMaker.make(threadID));


### PR DESCRIPTION
Change statistics collection mechanism:

- Statistics are now keyed on strings, and are stored in a LinkedHashMap.
- All collected statistics are printed.
- Migrated code which collected statistics on number of slots and constraints from `SolverEngine` to `StatisticRecorder`, and generalized it to collect stats based on the run-time class of each slot and constraint.
- Renamed `StatisticRecorder` to `Statistics`
- Added JUnit test for `Statistics` to test its static methods in a multithreaded environment.

Sample stats output for ontology:
```
====================== Statistics =======================
total_slots: 27
total_variable_slots: 20
constantslot: 7
variableslot: 18
existentialvariableslot: 2
total_constraints: 15
subtypeconstraint: 14
existentialconstraint: 1
=========================================================
```

Fixes https://github.com/opprop/checker-framework-inference/issues/85