### PR TITLE
Additional normalization cases

### DIFF
--- a/src/checkers/inference/model/ComparableConstraint.java
+++ b/src/checkers/inference/model/ComparableConstraint.java
@@ -33,8 +33,8 @@ public class ComparableConstraint extends Constraint implements BinaryConstraint
         }
 
         // Normalization cases:
-        // C1 == C2 => TRUE/FALSE depending on relationship
-        // V == V => TRUE (every type is always comparable to itself)
+        // C1 <~> C2 => TRUE/FALSE depending on relationship
+        // V <~> V => TRUE (every type is always comparable to itself)
         // otherwise => CREATE_REAL_COMPARABLE_CONSTRAINT
 
         if (first instanceof ConstantSlot && second instanceof ConstantSlot) {

--- a/src/checkers/inference/model/ComparableConstraint.java
+++ b/src/checkers/inference/model/ComparableConstraint.java
@@ -32,6 +32,11 @@ public class ComparableConstraint extends Constraint implements BinaryConstraint
                     + first + " Supertype: " + second);
         }
 
+        // Normalization cases:
+        // C1 == C2 => TRUE/FALSE depending on relationship
+        // V == V => TRUE (every type is always comparable to itself)
+        // otherwise => CREATE_REAL_COMPARABLE_CONSTRAINT
+
         if (first instanceof ConstantSlot && second instanceof ConstantSlot) {
             ConstantSlot firstConst = (ConstantSlot) first;
             ConstantSlot secondConst = (ConstantSlot) second;
@@ -40,6 +45,12 @@ public class ComparableConstraint extends Constraint implements BinaryConstraint
                     || realQualHierarchy.isSubtype(secondConst.getValue(), firstConst.getValue())
                             ? AlwaysTrueConstraint.create()
                             : AlwaysFalseConstraint.create();
+        }
+
+        // V == V => TRUE
+        if (first instanceof VariableSlot && second instanceof VariableSlot
+                && first.equals(second)) {
+            return AlwaysTrueConstraint.create();
         }
 
         return new ComparableConstraint(first, second, location);

--- a/src/checkers/inference/model/EqualityConstraint.java
+++ b/src/checkers/inference/model/EqualityConstraint.java
@@ -49,6 +49,12 @@ public class EqualityConstraint extends Constraint implements BinaryConstraint {
                     + first + " Supertype: " + second);
         }
 
+        // Normalization cases:
+        // C1 == C2 => TRUE/FALSE depending on annotation
+        // V == V => TRUE
+        // otherwise => CREATE_REAL_EQUALITY_CONSTRAINT
+
+        // C1 == C2 => TRUE/FALSE depending on annotation
         if (first instanceof ConstantSlot && second instanceof ConstantSlot) {
             ConstantSlot firstConst = (ConstantSlot) first;
             ConstantSlot secondConst = (ConstantSlot) second;
@@ -56,6 +62,12 @@ public class EqualityConstraint extends Constraint implements BinaryConstraint {
             return AnnotationUtils.areSame(firstConst.getValue(), secondConst.getValue())
                     ? AlwaysTrueConstraint.create()
                     : AlwaysFalseConstraint.create();
+        }
+
+        // V == V => TRUE
+        if (first instanceof VariableSlot && second instanceof VariableSlot
+                && first.equals(second)) {
+            return AlwaysTrueConstraint.create();
         }
 
         return new EqualityConstraint(first, second, location);

--- a/src/checkers/inference/model/InequalityConstraint.java
+++ b/src/checkers/inference/model/InequalityConstraint.java
@@ -27,6 +27,11 @@ public class InequalityConstraint extends Constraint implements BinaryConstraint
                     + first + " Supertype: " + second);
         }
 
+        // Normalization cases:
+        // C1 == C2 => TRUE/FALSE depending on annotation
+        // V == V => FALSE
+        // otherwise => CREATE_REAL_INEQUALITY_CONSTRAINT
+
         if (first instanceof ConstantSlot && second instanceof ConstantSlot) {
             ConstantSlot firstConst = (ConstantSlot) first;
             ConstantSlot secondConst = (ConstantSlot) second;
@@ -34,6 +39,12 @@ public class InequalityConstraint extends Constraint implements BinaryConstraint
             return !AnnotationUtils.areSame(firstConst.getValue(), secondConst.getValue())
                     ? AlwaysTrueConstraint.create()
                     : AlwaysFalseConstraint.create();
+        }
+
+        // V == V => FALSE
+        if (first instanceof VariableSlot && second instanceof VariableSlot
+                && first.equals(second)) {
+            return AlwaysFalseConstraint.create();
         }
 
         return new InequalityConstraint(first, second, location);

--- a/src/checkers/inference/model/InequalityConstraint.java
+++ b/src/checkers/inference/model/InequalityConstraint.java
@@ -28,8 +28,8 @@ public class InequalityConstraint extends Constraint implements BinaryConstraint
         }
 
         // Normalization cases:
-        // C1 == C2 => TRUE/FALSE depending on annotation
-        // V == V => FALSE
+        // C1 != C2 => TRUE/FALSE depending on annotation
+        // V != V => FALSE
         // otherwise => CREATE_REAL_INEQUALITY_CONSTRAINT
 
         if (first instanceof ConstantSlot && second instanceof ConstantSlot) {

--- a/src/checkers/inference/model/SubtypeConstraint.java
+++ b/src/checkers/inference/model/SubtypeConstraint.java
@@ -57,6 +57,7 @@ public class SubtypeConstraint extends Constraint implements BinaryConstraint {
         // V2 <: BOTTOM => REPLACE_WITH_EQUALITY
         // BOTTOM <: V2 => TRUE
         // TOP <: V2 => REPLACE_WITH_EQUALITY
+        // V <: V => TRUE
         // V1 <: V2 => CREATE_REAL_SUBTYPE_CONSTRAINT
 
         // C1 <: C2 => TRUE/FALSE depending on relationship
@@ -92,8 +93,14 @@ public class SubtypeConstraint extends Constraint implements BinaryConstraint {
         }
 
         // The are no constant-constant cases in encoder
-        // V1 <: V2 => CREATE_REAL_SUBTYPE_CONSTRAINT
-        return new SubtypeConstraint(subtype, supertype, location);
+        // V1 <: V2
+        if (subtype.equals(supertype)) {
+            // V <: V => TRUE
+            return AlwaysTrueConstraint.create();
+        } else {
+            // V1 <: V2 => CREATE_REAL_SUBTYPE_CONSTRAINT
+            return new SubtypeConstraint(subtype, supertype, location);
+        }
     }
 
     private static boolean isTop(QualifierHierarchy realQualHierarchy, ConstantSlot slot) {


### PR DESCRIPTION
`equals()` method returns true for 2 variable slots that have the same ID, so we can perform further normalizations.

New cases:
V <: V => AlwaysTrue
V == V => AlwaysTrue
V != V => AlwaysFalse
V <~> V => AlwaysTrue

where V is a VariableSlot