### PR TITLE
update gradle script to be able to run each test individually by its name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,14 +213,13 @@ task testDataflowExternalSolvers(type: Exec, dependsOn: [dist, dependenciesJar])
 }
 
 afterEvaluate {
-    // Create a task for each JUnit test class whose name is the same as the JUnit class name.
+    // Create a task for each test class whose name is the same as the class name.
     sourceSets.test.java.filter {
             it.path.contains('tests/checkers') &&
             it.path.endsWith('Test.java') &&
             !it.path.contains('CFInferenceTest')
         }.forEach { file ->
         String junitClassName = file.name.replaceAll(".java", "")
-        // println junitClassName
         tasks.create(name: "${junitClassName}", type: Test, group: 'Verification') {
             description "Run ${junitClassName} tests."
             include "**/${name}.class"

--- a/build.gradle
+++ b/build.gradle
@@ -104,40 +104,6 @@ task buildDLJC(type: Exec) {
 
 test {
     dependsOn(shadowJar)
-
-    systemProperties 'path.afu.scripts': "${afu}/scripts",
-            'path.inference.script': "${projectDir}/scripts/inference",
-            'use.hacks': true,
-            JDK_JAR: "${checkerFrameworkPath}/checker/dist/jdk8.jar"
-
-    if (project.hasProperty('emit.test.debug')) {
-        systemProperties += ["emit.test.debug": 'true']
-    }
-
-    testLogging {
-        // Always run the tests
-        outputs.upToDateWhen { false }
-        // The following prints out each time a test is passed.
-        // events "passed", "skipped", "failed", "standardOut", "standardError"
-
-        // Show the found unexpected diagnostics and expected diagnostics not found.
-        exceptionFormat "full"
-    }
-
-    // After each test, print a summary.
-    afterSuite { desc, result ->
-        if (desc.getClassName() != null) {
-            long mils = result.getEndTime() - result.getStartTime()
-            double seconds = mils / 1000.0
-
-            println "Testsuite: ${desc.getClassName()}\n" +
-                    "Tests run: ${result.testCount}, " +
-                    "Failures: ${result.failedTestCount}, " +
-                    "Skipped: ${result.skippedTestCount}, " +
-                    "Time elapsed: ${seconds} sec\n"
-        }
-
-    }
 }
 
 compileJava {
@@ -244,6 +210,61 @@ task testCheckerInferenceDevScript(type: Exec, dependsOn: [dist, dependenciesJar
 task testDataflowExternalSolvers(type: Exec, dependsOn: [dist, dependenciesJar]) {
     description 'Test Dataflow type system on its external solvers Lingeling and LogicBlox'
     executable './testing/dataflowexample/travis-test.sh'
+}
+
+afterEvaluate {
+    // Create a task for each JUnit test class whose name is the same as the JUnit class name.
+    sourceSets.test.java.filter {
+            it.path.contains('tests/checkers') &&
+            it.path.endsWith('Test.java') &&
+            !it.path.contains('CFInferenceTest')
+        }.forEach { file ->
+        String junitClassName = file.name.replaceAll(".java", "")
+        // println junitClassName
+        tasks.create(name: "${junitClassName}", type: Test, group: 'Verification') {
+            description "Run ${junitClassName} tests."
+            include "**/${name}.class"
+        }
+    }
+
+    // Configure Tests
+    tasks.withType(Test) {
+        dependsOn(shadowJar)
+
+        systemProperties 'path.afu.scripts': "${afu}/scripts",
+                'path.inference.script': "${projectDir}/scripts/inference",
+                'use.hacks': true,
+                JDK_JAR: "${checkerFrameworkPath}/checker/dist/jdk8.jar"
+
+        if (project.hasProperty('emit.test.debug')) {
+            systemProperties += ["emit.test.debug": 'true']
+        }
+
+        testLogging {
+            showStandardStreams = true
+            // Always run the tests
+            outputs.upToDateWhen { false }
+            // The following prints out each time a test is passed.
+            // events "passed", "skipped", "failed", "standardOut", "standardError"
+            events "failed"
+            // Show the found unexpected diagnostics and expected diagnostics not found.
+            exceptionFormat "full"
+        }
+
+        // After each test, print a summary.
+        afterSuite { desc, result ->
+            if (desc.getClassName() != null) {
+                long mils = result.getEndTime() - result.getStartTime()
+                double seconds = mils / 1000.0
+
+                println "Testsuite: ${desc.getClassName()}\n" +
+                        "Tests run: ${result.testCount}, " +
+                        "Failures: ${result.failedTestCount}, " +
+                        "Skipped: ${result.skippedTestCount}, " +
+                        "Time elapsed: ${seconds} sec\n"
+            }
+        }
+    }
 }
 
 /// Commented out because plugins section is commented out

--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,6 @@ afterEvaluate {
         }
 
         testLogging {
-            showStandardStreams = true
             // Always run the tests
             outputs.upToDateWhen { false }
             // The following prints out each time a test is passed.

--- a/tests/checkers/inference/DataflowInferenceTest.java
+++ b/tests/checkers/inference/DataflowInferenceTest.java
@@ -11,9 +11,9 @@ import org.junit.runners.Parameterized.Parameters;
 import checkers.inference.test.CFInferenceTest;
 import dataflow.solvers.general.DataflowSolverEngine;
 
-public class DataflowTest extends CFInferenceTest {
+public class DataflowInferenceTest extends CFInferenceTest {
 
-    public DataflowTest(File testFile) {
+    public DataflowInferenceTest(File testFile) {
         super(testFile,  dataflow.DataflowChecker.class, "dataflow",
               "-Anomsgtext", "-d", "tests/build/outputdir");
     }

--- a/tests/checkers/typecheck/DataflowTypecheckTest.java
+++ b/tests/checkers/typecheck/DataflowTypecheckTest.java
@@ -8,9 +8,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DataflowTest extends CheckerFrameworkPerFileTest {
+public class DataflowTypecheckTest extends CheckerFrameworkPerFileTest {
 
-    public DataflowTest(File testFile) {
+    public DataflowTypecheckTest(File testFile) {
         super(testFile,  dataflow.DataflowChecker.class, "dataflow",
                 "-Anomsgtext", "-d", "tests/build/outputdir");
     }


### PR DESCRIPTION
each test is now individually invokeable by its name, and the list is shown on `gradle tasks` :

```
Verification tasks
------------------
check - Runs all checks.
DataflowInferenceTest - Run DataflowInferenceTest tests.
DataflowTypecheckTest - Run DataflowTypecheckTest tests.
DefaultSlotManagerTest - Run DefaultSlotManagerTest tests.
IFlowSinkPropTest - Run IFlowSinkPropTest tests.
IFlowSinkSatTest - Run IFlowSinkSatTest tests.
IFlowSourcePropTest - Run IFlowSourcePropTest tests.
IFlowSourceSatTest - Run IFlowSourceSatTest tests.
InterningTest - Run InterningTest tests.
OsTrustedTest - Run OsTrustedTest tests.
OstrustedTest - Run OstrustedTest tests.
test - Runs the unit tests.
```

also renamed the two Dataflow tests so they have unique names for the gradle menu