### PR TITLE
Add clone and build deps target

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -26,7 +26,7 @@ if [[ "${GROUP}" != "cfi-tests" && "${GROUP}" != downstream* && "${GROUP}" != "a
   exit 1
 fi
 
-. ./gradlew cloneAndBuildDependencies
+. ./.travis-build-without-test.sh
 
 # Test CF Inference
 if [[ "${GROUP}" == "cfi-tests" || "${GROUP}" == "all" ]]; then

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -26,7 +26,7 @@ if [[ "${GROUP}" != "cfi-tests" && "${GROUP}" != downstream* && "${GROUP}" != "a
   exit 1
 fi
 
-./gradlew cloneAndBuildDependencies
+. ./gradlew cloneAndBuildDependencies
 
 # Test CF Inference
 if [[ "${GROUP}" == "cfi-tests" || "${GROUP}" == "all" ]]; then

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -26,7 +26,7 @@ if [[ "${GROUP}" != "cfi-tests" && "${GROUP}" != downstream* && "${GROUP}" != "a
   exit 1
 fi
 
-. ./.travis-build-without-test.sh
+./gradlew cloneAndBuildDependencies
 
 # Test CF Inference
 if [[ "${GROUP}" == "cfi-tests" || "${GROUP}" == "all" ]]; then

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ To build:
 gradle dist
 ````
 
+To clone and build all dependencies:
+
+````
+gradle cloneAndBuildDependencies
+````
+
+To test the build
+````
+gradle testCheckerInferenceScript
+gradle testCheckerInferenceDevScript
+gradle testDataflowExternalSolvers
+````
+
 
 Execution
 ---------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ project depends on the eclipse projects from Checker Framework.
 3) Build the dependencies jar file:
 
 ````
-gradle dependenciesJar
+./gradlew dependenciesJar
 ````
 
 4) Enter the main Eclipse working screen and in the “File” menu, select “Import” -> “General” -> “Existing Projects into workspace”.
@@ -73,23 +73,23 @@ with
 Building
 --------
 
-To build:
-
-````
-gradle dist
-````
-
 To clone and build all dependencies:
 
 ````
-gradle cloneAndBuildDependencies
+./gradlew cloneAndBuildDependencies
 ````
 
-To test the build
+To build:
+
 ````
-gradle testCheckerInferenceScript
-gradle testCheckerInferenceDevScript
-gradle testDataflowExternalSolvers
+./gradlew dist
+````
+
+To test the build:
+````
+./gradlew testCheckerInferenceScript
+./gradlew testCheckerInferenceDevScript
+./gradlew testDataflowExternalSolvers
 ````
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,11 @@ task release(type: Zip) {
     baseName = 'release'
 }
 
+task cloneAndBuildDependencies(type: Exec) {
+    description 'Clones (or updates) and builds all dependencies'
+    executable './.travis-build-without-test.sh'
+    args = ['downloadjdk']
+}
 
 task testCheckerInferenceScript(type: Exec, dependsOn: dist) {
     description 'Basic sanity check of scripts/inference'

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,6 @@ task release(type: Zip) {
 task cloneAndBuildDependencies(type: Exec) {
     description 'Clones (or updates) and builds all dependencies'
     executable './.travis-build-without-test.sh'
-    args = ['downloadjdk']
 }
 
 task testCheckerInferenceScript(type: Exec, dependsOn: dist) {


### PR DESCRIPTION
This PR fixes #207. It adds a new Gradle target `cloneAndBuildDependencies`, adapts the Travis build script to call it, and updates the README file accordingly.