### PR TITLE
Constraint hashcode equals fix

### DIFF
--- a/src/checkers/inference/ConstraintNormalizer.java
+++ b/src/checkers/inference/ConstraintNormalizer.java
@@ -239,8 +239,8 @@ public class ConstraintNormalizer {
                 return constraints;
             }
 
-            List<Constraint> ifExistsConstraints = new ArrayList<>();
-            List<Constraint> ifNotExistsConstraints = new ArrayList<>();
+            Set<Constraint> ifExistsConstraints = new HashSet<>();
+            Set<Constraint> ifNotExistsConstraints = new HashSet<>();
 
             ifExistsConstraints.addAll(constraints);
             for (final ExistentialNode existNode : ifExists.values()) {

--- a/src/checkers/inference/model/ArithmeticConstraint.java
+++ b/src/checkers/inference/model/ArithmeticConstraint.java
@@ -104,7 +104,7 @@ public class ArithmeticConstraint extends Constraint {
     public int hashCode() {
         // We do not hash on annotation location as the result slot is unique for each annotation
         // location
-        return HashCodeUtils.hash(operation, leftOperand, rightOperand, result);
+        return HashCodeUtils.hash(3079, operation, leftOperand, rightOperand, result);
     }
 
     @Override

--- a/src/checkers/inference/model/CombineConstraint.java
+++ b/src/checkers/inference/model/CombineConstraint.java
@@ -1,6 +1,8 @@
 package checkers.inference.model;
 
 import java.util.Arrays;
+
+import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.BugInCF;
 
 /**
@@ -51,28 +53,19 @@ public class CombineConstraint extends Constraint {
 
     @Override
     public int hashCode() {
-        int hc = 1;
-        hc += ((target == null) ? 0 : target.hashCode());
-        hc += ((decl == null) ? 0 : decl.hashCode());
-        hc += ((result == null) ? 0 : result.hashCode());
-        return hc;
+        return HashCodeUtils.hash(1543, target, decl, result);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        CombineConstraint other = (CombineConstraint) obj;
-        if (target.equals(other.target) &&
-                decl.equals(other.decl) &&
-                result.equals(other.result)) {
-            return true;
-        } else {
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
+        CombineConstraint other = (CombineConstraint) obj;
+        return target.equals(other.target) && decl.equals(other.decl)
+                && result.equals(other.result);
     }
 }

--- a/src/checkers/inference/model/ComparableConstraint.java
+++ b/src/checkers/inference/model/ComparableConstraint.java
@@ -81,7 +81,8 @@ public class ComparableConstraint extends Constraint implements BinaryConstraint
 
     @Override
     public int hashCode() {
-        return HashCodeUtils.hash(769, first, second);
+        // ComparableConstraint is insensitive to the order of the slots
+        return HashCodeUtils.hash(769, first.hashCode() + second.hashCode());
     }
 
     @Override

--- a/src/checkers/inference/model/ComparableConstraint.java
+++ b/src/checkers/inference/model/ComparableConstraint.java
@@ -2,6 +2,7 @@ package checkers.inference.model;
 
 import java.util.Arrays;
 
+import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.BugInCF;
 
@@ -80,26 +81,19 @@ public class ComparableConstraint extends Constraint implements BinaryConstraint
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = result + ((first == null) ? 0 : first.hashCode());
-        result = result + ((second == null) ? 0 : second.hashCode());
-        return result;
+        return HashCodeUtils.hash(769, first, second);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ComparableConstraint other = (ComparableConstraint) obj;
-        if ((first.equals(other.first) && second.equals(other.second))
-                || (first.equals(other.second) && (second.equals(other.first)))) {
-            return true;
-        } else {
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
+        ComparableConstraint other = (ComparableConstraint) obj;
+        return (first.equals(other.first) && second.equals(other.second))
+                || (first.equals(other.second) && second.equals(other.first));
     }
 }

--- a/src/checkers/inference/model/ConstraintManager.java
+++ b/src/checkers/inference/model/ConstraintManager.java
@@ -138,7 +138,7 @@ public class ConstraintManager {
      * Creates an {@link ExistentialConstraint} for the given slot and lists of constraints.
      */
     public ExistentialConstraint createExistentialConstraint(Slot slot,
-            List<Constraint> ifExistsConstraints, List<Constraint> ifNotExistsConstraints) {
+            Set<Constraint> ifExistsConstraints, Set<Constraint> ifNotExistsConstraints) {
         return ExistentialConstraint.create((VariableSlot) slot, ifExistsConstraints,
                 ifNotExistsConstraints, getCurrentLocation());
     }
@@ -267,8 +267,8 @@ public class ConstraintManager {
     /**
      * Creates and adds a {@link ExistentialConstraint} to the constraint set.
      */
-    public void addExistentialConstraint(Slot slot, List<Constraint> ifExistsConstraints,
-            List<Constraint> ifNotExistsConstraints) {
+    public void addExistentialConstraint(Slot slot, Set<Constraint> ifExistsConstraints,
+            Set<Constraint> ifNotExistsConstraints) {
         add(createExistentialConstraint(slot, ifExistsConstraints, ifNotExistsConstraints));
     }
 

--- a/src/checkers/inference/model/EqualityConstraint.java
+++ b/src/checkers/inference/model/EqualityConstraint.java
@@ -2,6 +2,7 @@ package checkers.inference.model;
 
 import java.util.Arrays;
 
+import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.BugInCF;
 
 /**
@@ -95,26 +96,19 @@ public class EqualityConstraint extends Constraint implements BinaryConstraint {
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = result + ((first == null) ? 0 : first.hashCode());
-        result = result + ((second == null) ? 0 : second.hashCode());
-        return result;
+        return HashCodeUtils.hash(97, first, second);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        EqualityConstraint other = (EqualityConstraint) obj;
-        if ((first.equals(other.first) && second.equals(other.second))
-                || (first.equals(other.second) && (second.equals(other.first)))) {
-            return true;
-        } else {
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
+        EqualityConstraint other = (EqualityConstraint) obj;
+        return (first.equals(other.first) && second.equals(other.second))
+                || (first.equals(other.second) && second.equals(other.first));
     }
 }

--- a/src/checkers/inference/model/EqualityConstraint.java
+++ b/src/checkers/inference/model/EqualityConstraint.java
@@ -96,7 +96,8 @@ public class EqualityConstraint extends Constraint implements BinaryConstraint {
 
     @Override
     public int hashCode() {
-        return HashCodeUtils.hash(97, first, second);
+        // EqualityConstraint is insensitive to the order of the slots
+        return HashCodeUtils.hash(97, first.hashCode() + second.hashCode());
     }
 
     @Override

--- a/src/checkers/inference/model/ImplicationConstraint.java
+++ b/src/checkers/inference/model/ImplicationConstraint.java
@@ -145,7 +145,7 @@ public class ImplicationConstraint extends Constraint {
 
     @Override
     public int hashCode() {
-        return HashCodeUtils.hash(assumptions, conclusion);
+        return HashCodeUtils.hash(12289, assumptions, conclusion);
     }
 
     @Override

--- a/src/checkers/inference/model/InequalityConstraint.java
+++ b/src/checkers/inference/model/InequalityConstraint.java
@@ -74,7 +74,8 @@ public class InequalityConstraint extends Constraint implements BinaryConstraint
 
     @Override
     public int hashCode() {
-        return HashCodeUtils.hash(193, first, second);
+        // InequalityConstraint is insensitive to the order of the slots
+        return HashCodeUtils.hash(193, first.hashCode() + second.hashCode());
     }
 
     @Override

--- a/src/checkers/inference/model/InequalityConstraint.java
+++ b/src/checkers/inference/model/InequalityConstraint.java
@@ -2,6 +2,7 @@ package checkers.inference.model;
 
 import java.util.Arrays;
 
+import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.BugInCF;
 
 public class InequalityConstraint extends Constraint implements BinaryConstraint {
@@ -73,26 +74,19 @@ public class InequalityConstraint extends Constraint implements BinaryConstraint
 
     @Override
     public int hashCode() {
-        int result = 1;
-        result = result + ((first == null) ? 0 : first.hashCode());
-        result = result + ((second == null) ? 0 : second.hashCode());
-        return result;
+        return HashCodeUtils.hash(193, first, second);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        InequalityConstraint other = (InequalityConstraint) obj;
-        if ((first.equals(other.first) && second.equals(other.second))
-                || (first.equals(other.second) && (second.equals(other.first)))) {
-            return true;
-        } else {
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
+        InequalityConstraint other = (InequalityConstraint) obj;
+        return (first.equals(other.first) && second.equals(other.second))
+                || (first.equals(other.second) && second.equals(other.first));
     }
 }

--- a/src/checkers/inference/model/PreferenceConstraint.java
+++ b/src/checkers/inference/model/PreferenceConstraint.java
@@ -1,6 +1,8 @@
 package checkers.inference.model;
 
 import java.util.Arrays;
+
+import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.BugInCF;
 
 /**
@@ -49,40 +51,18 @@ public class PreferenceConstraint extends Constraint {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((variable == null) ? 0 : variable.hashCode());
-        result = prime * result
-                + ((goal == null) ? 0 : goal.hashCode());
-        result = prime * result + weight;
-        return result;
+        return HashCodeUtils.hash(6151, variable, goal);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
-        if (getClass() != obj.getClass())
-            return false;
+        }
         PreferenceConstraint other = (PreferenceConstraint) obj;
-        if (variable == null) {
-            if (other.variable != null) {
-                return false;
-            }
-        } else if (!variable.equals(other.variable)) {
-            return false;
-        }
-
-        if (goal == null) {
-            if (other.goal != null) {
-                return false;
-            }
-        } else if (!goal.equals(other.goal)) {
-            return false;
-        }
-
-        return weight == other.weight;
+        return variable.equals(other.variable) && goal.equals(other.goal);
     }
 }

--- a/src/checkers/inference/model/SubtypeConstraint.java
+++ b/src/checkers/inference/model/SubtypeConstraint.java
@@ -2,6 +2,7 @@ package checkers.inference.model;
 
 import java.util.Arrays;
 
+import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.BugInCF;
 
@@ -126,34 +127,19 @@ public class SubtypeConstraint extends Constraint implements BinaryConstraint {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((subtype == null) ? 0 : subtype.hashCode());
-        result = prime * result
-                + ((supertype == null) ? 0 : supertype.hashCode());
-        return result;
+        return HashCodeUtils.hash(53, subtype, supertype);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
-        if (getClass() != obj.getClass())
-            return false;
+        }
         SubtypeConstraint other = (SubtypeConstraint) obj;
-        if (subtype == null) {
-            if (other.subtype != null)
-                return false;
-        } else if (!subtype.equals(other.subtype))
-            return false;
-        if (supertype == null) {
-            if (other.supertype != null)
-                return false;
-        } else if (!supertype.equals(other.supertype))
-            return false;
-        return true;
+        return subtype.equals(other.subtype) && supertype.equals(other.supertype);
     }
 
     /**

--- a/src/checkers/inference/model/serialization/JsonDeserializer.java
+++ b/src/checkers/inference/model/serialization/JsonDeserializer.java
@@ -69,14 +69,14 @@ public class JsonDeserializer {
         this.constraintManager = InferenceMain.getInstance().getConstraintManager();
     }
 
-    public List<Constraint> parseConstraints() throws ParseException {
+    public Set<Constraint> parseConstraints() throws ParseException {
         JSONArray constraints = (JSONArray) root.get(CONSTRAINTS_KEY);
-        List<Constraint> results = jsonArrayToConstraints(constraints);
+        Set<Constraint> results = jsonArrayToConstraints(constraints);
         return results;
     }
 
-    public List<Constraint> jsonArrayToConstraints(final JSONArray jsonConstraints) {
-        List<Constraint> results = new LinkedList<Constraint>();
+    public Set<Constraint> jsonArrayToConstraints(final JSONArray jsonConstraints) {
+        Set<Constraint> results = new HashSet<>();
 
         for (Object obj: jsonConstraints) {
             if (obj instanceof String) {
@@ -111,9 +111,9 @@ public class JsonDeserializer {
                     results.add(constraintManager.createComparableConstraint(lhs, rhs));
                 } else if (EXISTENTIAL_CONSTRAINT_KEY.equals(constraintType)) {
                     Slot potential = parseSlot((String) constraint.get(EXISTENTIAL_ID));
-                    List<Constraint> thenConstraints =
+                    Set<Constraint> thenConstraints =
                             jsonArrayToConstraints((JSONArray) constraint.get(EXISTENTIAL_THEN));
-                    List<Constraint> elseConstraints =
+                    Set<Constraint> elseConstraints =
                             jsonArrayToConstraints((JSONArray) constraint.get(EXISTENTIAL_ELSE));
                     results.add(constraintManager.createExistentialConstraint((VariableSlot) potential,
                             thenConstraints, elseConstraints));

--- a/tests/checkers/inference/model/ConstraintsHashcodeEqualsTest.java
+++ b/tests/checkers/inference/model/ConstraintsHashcodeEqualsTest.java
@@ -153,7 +153,7 @@ public class ConstraintsHashcodeEqualsTest {
         constraintMap.put(mulCon, 4);
         constraintMap.put(combCon, 5);
         constraintMap.put(compCon, 6);
-        constraintMap.put(compCon2, 66);
+        constraintMap.put(compCon2, 66); // compCon2 has the same hashcode as compCon
         constraintMap.put(eqCon, 7);
         constraintMap.put(neqCon, 8);
         constraintMap.put(exCon, 9);

--- a/tests/checkers/inference/model/ConstraintsHashcodeEqualsTest.java
+++ b/tests/checkers/inference/model/ConstraintsHashcodeEqualsTest.java
@@ -1,0 +1,177 @@
+package checkers.inference.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import checkers.inference.model.ArithmeticConstraint.ArithmeticOperationKind;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConstraintsHashcodeEqualsTest {
+    ConstraintManager manager;
+    Set<Constraint> constraintSet;
+    Map<Constraint, Integer> constraintMap;
+
+    AnnotationLocation dummyLocation;
+    VariableSlot one;
+    VariableSlot two;
+    VariableSlot three;
+    ArithmeticVariableSlot arithRes;
+    CombVariableSlot combRes;
+    // use Mockito to build a constant slot as AnnotationBuilder requires a ProcessingEnvironment,
+    // this CS has id 0
+    @Mock ConstantSlot goal;
+
+    AlwaysTrueConstraint atCon;
+    AlwaysFalseConstraint afCon;
+    ArithmeticConstraint addCon;
+    ArithmeticConstraint mulCon;
+    CombineConstraint combCon;
+    Constraint compCon;
+    Constraint compCon2;
+    Constraint eqCon;
+    Constraint eqCon2;
+    Constraint neqCon;
+    Constraint neqCon2;
+    Constraint exCon;
+    Constraint impCon;
+    PreferenceConstraint prefCon;
+    Constraint stCon;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        manager = new ConstraintManager();
+        constraintSet = new HashSet<>();
+        constraintMap = new HashMap<>();
+
+        dummyLocation = new AnnotationLocation.ClassDeclLocation("java.lang.Number");
+        one = new VariableSlot(5);
+        two = new VariableSlot(6);
+        three = new VariableSlot(7);
+        arithRes = new ArithmeticVariableSlot(dummyLocation, 8);
+        combRes = new CombVariableSlot(dummyLocation, 9, one, two);
+
+        atCon = AlwaysTrueConstraint.create();
+        afCon = AlwaysFalseConstraint.create();
+        addCon = ArithmeticConstraint.create(ArithmeticOperationKind.PLUS, one, two, arithRes,
+                dummyLocation);
+        mulCon = ArithmeticConstraint.create(ArithmeticOperationKind.MULTIPLY, one, two, arithRes,
+                dummyLocation);
+        combCon = CombineConstraint.create(one, two, combRes, dummyLocation);
+        compCon = ComparableConstraint.create(one, two, dummyLocation, null);
+        compCon2 = ComparableConstraint.create(two, one, dummyLocation, null);
+        eqCon = EqualityConstraint.create(one, two, dummyLocation);
+        eqCon2 = EqualityConstraint.create(two, one, dummyLocation);
+        neqCon = InequalityConstraint.create(one, two, dummyLocation);
+        neqCon2 = InequalityConstraint.create(two, one, dummyLocation);
+        exCon = ExistentialConstraint.create(one, new HashSet<>(Arrays.asList(atCon)),
+                new HashSet<>(Arrays.asList(atCon)), dummyLocation);
+        impCon = ImplicationConstraint.create(Arrays.asList(addCon), mulCon, dummyLocation);
+        prefCon = PreferenceConstraint.create(three, goal, 100, dummyLocation);
+        stCon = SubtypeConstraint.create(one, two, dummyLocation, null);
+    }
+
+    /**
+     * Tests the hashcode methods.
+     */
+    @Test
+    public void testConstraintHashcodeEqualsMethods() {
+        isDistinctHashcodes(atCon, afCon, addCon, mulCon, combCon, compCon, compCon2, eqCon, eqCon2,
+                neqCon, neqCon2, exCon, impCon, prefCon, stCon);
+    }
+
+    /**
+     * checks and ensures every constraint is distinct from each other
+     */
+    private void isDistinctHashcodes(Constraint... constraints) {
+        for (Constraint c : constraints) {
+            for (Constraint d : constraints) {
+                // if equals then hashcode must be same
+                if (c.equals(d)) {
+                    assertTrue("hashcode of " + c + " and " + d + " must be same.",
+                            c.hashCode() == d.hashCode());
+                }
+                // if not equals then hashcode must be different
+                else {
+                    assertFalse("hashcode of " + c + " and " + d + " must be different.",
+                            c.hashCode() == d.hashCode());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testConstraintSet() {
+        constraintSet.add(atCon);
+        constraintSet.add(afCon);
+        constraintSet.add(addCon);
+        constraintSet.add(mulCon);
+        constraintSet.add(combCon);
+        constraintSet.add(compCon);
+        constraintSet.add(compCon2);
+        constraintSet.add(eqCon);
+        constraintSet.add(neqCon);
+        constraintSet.add(exCon);
+        constraintSet.add(impCon);
+        constraintSet.add(prefCon);
+        constraintSet.add(stCon);
+
+        assertTrue(constraintSet.contains(atCon));
+        assertTrue(constraintSet.contains(afCon));
+        assertTrue(constraintSet.contains(addCon));
+        assertTrue(constraintSet.contains(mulCon));
+        assertTrue(constraintSet.contains(combCon));
+        assertTrue(constraintSet.contains(compCon));
+        assertTrue(constraintSet.contains(compCon2));
+        assertTrue(constraintSet.contains(eqCon));
+        assertTrue(constraintSet.contains(neqCon));
+        assertTrue(constraintSet.contains(exCon));
+        assertTrue(constraintSet.contains(impCon));
+        assertTrue(constraintSet.contains(prefCon));
+        assertTrue(constraintSet.contains(stCon));
+    }
+
+    @Test
+    public void testConstraintMap() {
+        constraintMap.put(atCon, 1);
+        constraintMap.put(afCon, 2);
+        constraintMap.put(addCon, 3);
+        constraintMap.put(mulCon, 4);
+        constraintMap.put(combCon, 5);
+        constraintMap.put(compCon, 6);
+        constraintMap.put(compCon2, 66);
+        constraintMap.put(eqCon, 7);
+        constraintMap.put(neqCon, 8);
+        constraintMap.put(exCon, 9);
+        constraintMap.put(impCon, 10);
+        constraintMap.put(prefCon, 11);
+        constraintMap.put(stCon, 12);
+
+        assertTrue(constraintMap.containsKey(atCon) && constraintMap.get(atCon) == 1);
+        assertTrue(constraintMap.containsKey(afCon) && constraintMap.get(afCon) == 2);
+        assertTrue(constraintMap.containsKey(addCon) && constraintMap.get(addCon) == 3);
+        assertTrue(constraintMap.containsKey(mulCon) && constraintMap.get(mulCon) == 4);
+        assertTrue(constraintMap.containsKey(combCon) && constraintMap.get(combCon) == 5);
+        assertTrue(constraintMap.containsKey(compCon) && constraintMap.get(compCon) == 66);
+        assertTrue(constraintMap.containsKey(eqCon) && constraintMap.get(eqCon) == 7);
+        assertTrue(constraintMap.containsKey(neqCon) && constraintMap.get(neqCon) == 8);
+        assertTrue(constraintMap.containsKey(exCon) && constraintMap.get(exCon) == 9);
+        assertTrue(constraintMap.containsKey(impCon) && constraintMap.get(impCon) == 10);
+        assertTrue(constraintMap.containsKey(prefCon) && constraintMap.get(prefCon) == 11);
+        assertTrue(constraintMap.containsKey(stCon) && constraintMap.get(stCon) == 12);
+    }
+}

--- a/tests/checkers/inference/model/ConstraintsHashcodeEqualsTest.java
+++ b/tests/checkers/inference/model/ConstraintsHashcodeEqualsTest.java
@@ -124,7 +124,9 @@ public class ConstraintsHashcodeEqualsTest {
         constraintSet.add(compCon);
         constraintSet.add(compCon2);
         constraintSet.add(eqCon);
+        constraintSet.add(eqCon2);
         constraintSet.add(neqCon);
+        constraintSet.add(neqCon2);
         constraintSet.add(exCon);
         constraintSet.add(impCon);
         constraintSet.add(prefCon);
@@ -138,7 +140,9 @@ public class ConstraintsHashcodeEqualsTest {
         assertTrue(constraintSet.contains(compCon));
         assertTrue(constraintSet.contains(compCon2));
         assertTrue(constraintSet.contains(eqCon));
+        assertTrue(constraintSet.contains(eqCon2));
         assertTrue(constraintSet.contains(neqCon));
+        assertTrue(constraintSet.contains(neqCon2));
         assertTrue(constraintSet.contains(exCon));
         assertTrue(constraintSet.contains(impCon));
         assertTrue(constraintSet.contains(prefCon));
@@ -155,7 +159,9 @@ public class ConstraintsHashcodeEqualsTest {
         constraintMap.put(compCon, 6);
         constraintMap.put(compCon2, 66); // compCon2 has the same hashcode as compCon
         constraintMap.put(eqCon, 7);
+        constraintMap.put(eqCon2, 77); // eqCon2 has the same hashcode as eqCon
         constraintMap.put(neqCon, 8);
+        constraintMap.put(neqCon2, 88); // neqCon2 has the same hashcode as neqCon2
         constraintMap.put(exCon, 9);
         constraintMap.put(impCon, 10);
         constraintMap.put(prefCon, 11);
@@ -167,8 +173,8 @@ public class ConstraintsHashcodeEqualsTest {
         assertTrue(constraintMap.containsKey(mulCon) && constraintMap.get(mulCon) == 4);
         assertTrue(constraintMap.containsKey(combCon) && constraintMap.get(combCon) == 5);
         assertTrue(constraintMap.containsKey(compCon) && constraintMap.get(compCon) == 66);
-        assertTrue(constraintMap.containsKey(eqCon) && constraintMap.get(eqCon) == 7);
-        assertTrue(constraintMap.containsKey(neqCon) && constraintMap.get(neqCon) == 8);
+        assertTrue(constraintMap.containsKey(eqCon) && constraintMap.get(eqCon) == 77);
+        assertTrue(constraintMap.containsKey(neqCon) && constraintMap.get(neqCon) == 88);
         assertTrue(constraintMap.containsKey(exCon) && constraintMap.get(exCon) == 9);
         assertTrue(constraintMap.containsKey(impCon) && constraintMap.get(impCon) == 10);
         assertTrue(constraintMap.containsKey(prefCon) && constraintMap.get(prefCon) == 11);


### PR DESCRIPTION
This PR fixes https://github.com/opprop/checker-framework-inference/issues/206. It updates the hashcode and quals methods of the constraints and adds a test suite to ensure their methods works as expected.