### PR TITLE
fix error in running "./gradlew testDataflowExternalSolvers"

### DIFF
--- a/testing/dataflowexample/travis-test.sh
+++ b/testing/dataflowexample/travis-test.sh
@@ -4,7 +4,7 @@ set -e
 
 WORKING_DIR=$(cd $(dirname "$0") && pwd)
 
-JSR308=$(cd $WORKING_DIR/../../../ && pwd)
+export JSR308=$(cd $WORKING_DIR/../../../ && pwd)
 
 export AFU=$JSR308/annotation-tools/annotation-file-utilities
 export LINGELING=$JSR308/lingeling


### PR DESCRIPTION
Hello, when I try to run `./gradlew testDataflowExternalSolvers`, there will be an error like this:

```
Running DataflowSolver

Traceback (most recent call last):
{'IM_CONFIG_PHASE': '2', 'LESS': '-R', 'QT4_IM_MODULE': 'fcitx', 'AUTOJUMP_DATA_DIR': '/home/teachertian/.local/share/autojump', 'GJS_DEBUG_OUTPUT': 'stderr', 'LC_CTYPE': 'en_CA.UTF-8', 'WINDOWPATH': '2', 'XDG_CURRENT_DESKTOP': 'ubuntu:GNOME', 'XDG_SESSION_TYPE': 'x11', 'QT_IM_MODULE': 'fcitx', 'LOGNAME': 'teachertian', 'USER': 'teachertian', 'PATH': '/home/teachertian/Documents/opprop/checker/lingeling:/home/teachertian/Documents/opprop/checker/annotation-tools/annotation-file-utilities/scripts:/home/teachertian/Documents/opprop/checker/checker-framework/checker/bin:/home/teachertian/.autojump/bin:/home/teachertian/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin', 'XDG_VTNR': '2', 'HOME': '/home/teachertian', 'ZSH': '/home/teachertian/.oh-my-zsh', 'DISPLAY': ':0', 'SSH_AGENT_PID': '1846', 'LANG': 'en_CA.UTF-8', 'TERM': 'xterm-256color', 'SHELL': '/usr/bin/zsh', 'XAUTHORITY': '/run/user/1000/gdm/Xauthority', 'SESSION_MANAGER': 'local/teachertian-ThinkPad-X1-Carbon-6th:@/tmp/.ICE-unix/1755,unix/teachertian-ThinkPad-X1-Carbon-6th:/tmp/.ICE-unix/1755', 'XDG_DATA_DIRS': '/usr/share/ubuntu:/usr/local/share:/usr/share:/var/lib/snapd/desktop', 'MANDATORY_PATH': '/usr/share/gconf/ubuntu.mandatory.path', 'QT_ACCESSIBILITY': '1', 'GNOME_DESKTOP_SESSION_ID': 'this-is-deprecated', 'CLUTTER_IM_MODULE': 'xim', 'TEXTDOMAIN': 'im-config', 'GNOME_TERMINAL_SERVICE': ':1.118', 'LINGELING': '/home/teachertian/Documents/opprop/checker/lingeling', 'JAVA_HOME': '/usr/lib/jvm/java-8-openjdk-amd64', 'USERNAME': 'teachertian', 'XDG_SESSION_DESKTOP': 'ubuntu', 'XDG_RUNTIME_DIR': '/run/user/1000', 'SSH_AUTH_SOCK': '/run/user/1000/keyring/ssh', 'VTE_VERSION': '5202', 'GPG_AGENT_INFO': '/run/user/1000/gnupg/S.gpg-agent:0:1', 'GDMSESSION': 'ubuntu', 'XMODIFIERS': '@im=fcitx', 'TEXTDOMAINDIR': '/usr/share/locale/', 'GNOME_SHELL_SESSION_MODE': 'ubuntu', 'AFU': '/home/teachertian/Documents/opprop/checker/annotation-tools/annotation-file-utilities', 'CHECKERFRAMEWORK': '/home/teachertia  File "/home/teachertian/Documents/opprop/checker/do-like-javac/dljc", line 5, in <module>
n/Documents/opprop/checker/checker-framework', 'XDG_SESSION_ID': '2', 'DBUS_SESSION_BUS_ADDRESS': 'unix:path=/run/user/1000/bus', '_': '/home/teachertian/Documents/opprop/checker/do-like-javac/dljc', 'GTK_MODULES': 'gail:atk-bridge', 'GTK_IM_MODULE': 'fcitx', 'DESKTOP_SESSION': 'ubuntu', 'LSCOLORS': 'Gxfxcxdxbxegedabagacad', 'XDG_CONFIG_DIRS': '/etc/xdg/xdg-ubuntu:/etc/xdg', 'DEFAULTS_PATH': '/usr/share/gconf/ubuntu.default.path', 'XDG_SEAT': 'seat0', 'OLDPWD': '/home/teachertian/Documents/opprop/checker/checker-framework-inference', 'SHLVL': '3', 'PWD': '/home/teachertian/Documents/opprop/checker/checker-framework-inference/testing/dataflowexample', 'COLORTERM': 'truecolor', 'XDG_MENU_PREFIX': 'gnome-', 'PAGER': 'less', 'GJS_DEBUG_TOPICS': 'JS ERROR;JS LOG', 'GNOME_TERMINAL_SCREEN': '/org/gnome/Terminal/screen/ff7346a3_1d83_4e98_88eb_e3fb1e65ec9c'}
    do_like_javac.run()
  File "/home/teachertian/Documents/opprop/checker/do-like-javac/do_like_javac/command.py", line 33, in main
    tools.run(args, javac_commands, jars)
  File "/home/teachertian/Documents/opprop/checker/do-like-javac/do_like_javac/tools/__init__.py", line 46, in run
    TOOLS[tool].run(args, javac_commands, jars)
  File "/home/teachertian/Documents/opprop/checker/do-like-javac/do_like_javac/tools/infer.py", line 33, in run
    cmd = get_tool_command(args, jc['javac_switches']['classpath'], jc['java_files'], jaif_file)
  File "/home/teachertian/Documents/opprop/checker/do-like-javac/do_like_javac/tools/infer.py", line 42, in get_tool_command
    CFI_dist = os.path.join(os.environ['JSR308'], 'checker-framework-inference', 'dist')
  File "/usr/lib/python2.7/UserDict.py", line 40, in __getitem__
    raise KeyError(key)
KeyError: 'JSR308'
```
I think it is because that **JSR308** was not set correctly, so I open this PR to fix it. 