### PR TITLE
Copy Lingeling to CIF/lib, resolve #215.

### DIFF
--- a/scripts/buildLingeling
+++ b/scripts/buildLingeling
@@ -15,34 +15,40 @@ then
     myDir="."
 fi
 
-ROOT=$(cd ${myDir}/../lib && pwd)
+ROOT=$(cd ${myDir}/../ && pwd)
+
+if [ ! -d $ROOT/lib ] ; then
+    mkdir $ROOT/lib
+fi
+
+LIB=$(cd ${ROOT}/lib/ && pwd)
 
 ## Fetching Lingeling solver
 LINGELING_ARCHIVE=http://fmv.jku.at/lingeling/lingeling-bcj-78ebb86-180517.tar.gz
 
-if [ -e $ROOT/lingeling/lingeling ] ; then
-    echo "Found existing lingeling in $ROOT/lingeling, exiting from the shell script."
+if [ -e $LIB/lingeling/lingeling ] ; then
+    echo "Found existing lingeling in $LIB/lingeling, exiting from the shell script."
     exit 0
-elif [ -e $ROOT/lingeling.tar.gz ] ; then
-    echo "Found existing lingeling.tar.gz in $ROOT, skip downloading lingeling."
+elif [ -e $$LIB/lingeling.tar.gz ] ; then
+    echo "Found existing lingeling.tar.gz in $LIB, skip downloading lingeling."
 else
     echo "Downloading lingeling from $LINGELING_ARCHIVE..."
-    echo "Running cmd: (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE)"
-    (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE)
-    echo "cmd: (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE) Done."
-    echo "Downloaded lingeling.tar.gz in directory $ROOT."
+    echo "Running cmd: (cd $LIB && wget -O lingeling.tar.gz $LINGELING_ARCHIVE)"
+    (cd $LIB && wget -O lingeling.tar.gz $LINGELING_ARCHIVE)
+    echo "cmd: (cd $LIB && wget -O lingeling.tar.gz $LINGELING_ARCHIVE) Done."
+    echo "Downloaded lingeling.tar.gz in directory $LIB."
 fi
 
 echo "Unziping lingeling.tar.gz..."
-    echo "Running cmd: (cd $ROOT && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)"
-    (cd $ROOT && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)
-    echo "cmd: (cd $ROOT && tar -xf lingeling.tar.gz && mv lingeling-* lingeling) Done."
-    echo "Unziped lingeling.tar.gz into directory $ROOT/lingeling."
+    echo "Running cmd: (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)"
+    (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)
+    echo "cmd: (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling) Done."
+    echo "Unziped lingeling.tar.gz into directory $LIB/lingeling."
 
 echo "Compiling lingeling..."
-    echo "Running cmd: (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version)"
-    (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version)
-    echo "cmd: (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version) Done."
+    echo "Running cmd: (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version)"
+    (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version)
+    echo "cmd: (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version) Done."
     echo "Compiled lingeling successfully."
 
 echo "Building lingeling done."

--- a/scripts/buildLingeling
+++ b/scripts/buildLingeling
@@ -34,3 +34,8 @@ else
     (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version)
     echo "cmd: (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version) Done."
 fi
+
+# Copy $ROOT/lingeling/lingeling into CFI lib dir
+echo "Copying $ROOT/lingeling/lingeling into $ROOT/checker-framework-inference/lib"
+(cp $ROOT/lingeling/lingeling $ROOT/checker-framework-inference/lib)
+echo "Copy done."

--- a/scripts/buildLingeling
+++ b/scripts/buildLingeling
@@ -15,27 +15,34 @@ then
     myDir="."
 fi
 
-ROOT=$(cd ${myDir}/../../ && pwd)
+ROOT=$(cd ${myDir}/../lib && pwd)
 
 ## Fetching Lingeling solver
 LINGELING_ARCHIVE=http://fmv.jku.at/lingeling/lingeling-bcj-78ebb86-180517.tar.gz
 
 if [ -e $ROOT/lingeling/lingeling ] ; then
-    echo "Found existing lingeling in $ROOT/lingeling/, skip downloading lingeling."
+    echo "Found existing lingeling in $ROOT/lingeling, exiting from the shell script."
+    exit 0
+elif [ -e $ROOT/lingeling.tar.gz ] ; then
+    echo "Found existing lingeling.tar.gz in $ROOT, skip downloading lingeling."
 else
     echo "Downloading lingeling from $LINGELING_ARCHIVE..."
-    echo "Running cmd: (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)"
-    (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)
-    echo "cmd: (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE && tar -xf lingeling.tar.gz && mv lingeling-* lingeling) Done."
-    echo "Downloaded lingeling into directory $ROOT/lingeling"
+    echo "Running cmd: (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE)"
+    (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE)
+    echo "cmd: (cd $ROOT && wget -O lingeling.tar.gz $LINGELING_ARCHIVE) Done."
+    echo "Downloaded lingeling.tar.gz in directory $ROOT."
+fi
 
-    echo "Compiling lingeling..."
+echo "Unziping lingeling.tar.gz..."
+    echo "Running cmd: (cd $ROOT && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)"
+    (cd $ROOT && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)
+    echo "cmd: (cd $ROOT && tar -xf lingeling.tar.gz && mv lingeling-* lingeling) Done."
+    echo "Unziped lingeling.tar.gz into directory $ROOT/lingeling."
+
+echo "Compiling lingeling..."
     echo "Running cmd: (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version)"
     (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version)
     echo "cmd: (cd $ROOT/lingeling && ./configure.sh && make --silent && ./lingeling --version) Done."
-fi
+    echo "Compiled lingeling successfully."
 
-# Copy $ROOT/lingeling/lingeling into CFI lib dir
-echo "Copying $ROOT/lingeling/lingeling into $ROOT/checker-framework-inference/lib"
-(cp $ROOT/lingeling/lingeling $ROOT/checker-framework-inference/lib)
-echo "Copy done."
+echo "Building lingeling done."

--- a/scripts/buildLingeling
+++ b/scripts/buildLingeling
@@ -15,13 +15,13 @@ then
     myDir="."
 fi
 
-ROOT=$(cd ${myDir}/../ && pwd)
+CFI=$(cd ${myDir}/../ && pwd)
 
-if [ ! -d $ROOT/lib ] ; then
-    mkdir $ROOT/lib
+if [ ! -d $CFI/lib ] ; then
+    mkdir $CFI/lib
 fi
 
-LIB=$(cd ${ROOT}/lib/ && pwd)
+LIB=$(cd ${CFI}/lib/ && pwd)
 
 ## Fetching Lingeling solver
 LINGELING_ARCHIVE=http://fmv.jku.at/lingeling/lingeling-bcj-78ebb86-180517.tar.gz
@@ -29,7 +29,7 @@ LINGELING_ARCHIVE=http://fmv.jku.at/lingeling/lingeling-bcj-78ebb86-180517.tar.g
 if [ -e $LIB/lingeling/lingeling ] ; then
     echo "Found existing lingeling in $LIB/lingeling, exiting from the shell script."
     exit 0
-elif [ -e $$LIB/lingeling.tar.gz ] ; then
+elif [ -e $LIB/lingeling.tar.gz ] ; then
     echo "Found existing lingeling.tar.gz in $LIB, skip downloading lingeling."
 else
     echo "Downloading lingeling from $LINGELING_ARCHIVE..."
@@ -40,15 +40,15 @@ else
 fi
 
 echo "Unziping lingeling.tar.gz..."
-    echo "Running cmd: (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)"
-    (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)
-    echo "cmd: (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling) Done."
-    echo "Unziped lingeling.tar.gz into directory $LIB/lingeling."
+echo "Running cmd: (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)"
+(cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling)
+echo "cmd: (cd $LIB && tar -xf lingeling.tar.gz && mv lingeling-* lingeling) Done."
+echo "Unziped lingeling.tar.gz into directory $LIB/lingeling."
 
 echo "Compiling lingeling..."
-    echo "Running cmd: (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version)"
-    (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version)
-    echo "cmd: (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version) Done."
-    echo "Compiled lingeling successfully."
+echo "Running cmd: (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version)"
+(cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version)
+echo "cmd: (cd $LIB/lingeling && ./configure.sh && make --silent && ./lingeling --version) Done."
+echo "Compiled lingeling successfully."
 
 echo "Building lingeling done."

--- a/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
+++ b/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
@@ -32,8 +32,9 @@ import checkers.inference.solver.util.Statistics;
  */
 public class LingelingSolver extends MaxSatSolver {
 
-    // Lingeling binary executable file should be located at JSR308/lingeling/lingeling.
-    private final String lingeling = System.getenv().get("JSR308") + "/lingeling/lingeling";
+    // Lingeling binary executable file should be located at checker-framework-inference/lib/lingeling.
+    private String currentWorkingDir = System.getProperty("user.dir");
+    private final String lingeling = currentWorkingDir.substring(0, currentWorkingDir.lastIndexOf("testing/")) + "lib/lingeling";
     // record cnf integers in clauses. lingeling solver give the answer for all
     // the integers from 1 to the largest one. Some of them may be not in the
     // clauses.

--- a/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
+++ b/src/checkers/inference/solver/backend/lingeling/LingelingSolver.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.nio.file.Paths;
 
 import javax.lang.model.element.AnnotationMirror;
 
@@ -33,8 +34,12 @@ import checkers.inference.solver.util.Statistics;
 public class LingelingSolver extends MaxSatSolver {
 
     // Lingeling binary executable file should be located at checker-framework-inference/lib/lingeling.
-    private String currentWorkingDir = System.getProperty("user.dir");
-    private final String lingeling = currentWorkingDir.substring(0, currentWorkingDir.lastIndexOf("testing/")) + "lib/lingeling";
+    private static final String CFIProjectName = "checker-framework-inference";
+    private String currentWorkingDirPath = System.getProperty("user.dir");
+    private String CFIDir = currentWorkingDirPath.substring(0, currentWorkingDirPath.lastIndexOf(CFIProjectName) +
+            CFIProjectName.length() + 1);
+    private final String lingeling = Paths.get(CFIDir, "lib", "lingeling", "lingeling").toString();
+
     // record cnf integers in clauses. lingeling solver give the answer for all
     // the integers from 1 to the largest one. Some of them may be not in the
     // clauses.

--- a/testing/dataflowexample/travis-test.sh
+++ b/testing/dataflowexample/travis-test.sh
@@ -7,7 +7,7 @@ WORKING_DIR=$(cd $(dirname "$0") && pwd)
 JSR308=$(cd $WORKING_DIR/../../../ && pwd)
 
 export AFU=$JSR308/annotation-tools/annotation-file-utilities
-export LINGELING=$JSR308/lingeling
+export LINGELING=$JSR308/checker-framework-inference/lib
 
 export PATH=$LINGELING:$AFU/scripts:$PATH
 

--- a/testing/dataflowexample/travis-test.sh
+++ b/testing/dataflowexample/travis-test.sh
@@ -7,7 +7,7 @@ WORKING_DIR=$(cd $(dirname "$0") && pwd)
 JSR308=$(cd $WORKING_DIR/../../../ && pwd)
 
 export AFU=$JSR308/annotation-tools/annotation-file-utilities
-export LINGELING=$JSR308/checker-framework-inference/lib
+export LINGELING=$JSR308/checker-framework-inference/lib/lingeling
 
 export PATH=$LINGELING:$AFU/scripts:$PATH
 


### PR DESCRIPTION
Hello, in this PR, I copy the executable file Lingeling to CIF/lib and change the corresponding code to support this change. I did not think out a better way to get the path of CIF, so I still use the `getProperty("user.dir")` function to achieve this. If you have any advice, please let me know.