### PR TITLE
Fix conflicting varannot

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -500,6 +500,10 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             if (variable.getLocation() == null) {
                 variable.setLocation(treeToLocation(tree));
             }
+            if (variable instanceof ConstantSlot) {
+            	atm.removeAnnotation(((ConstantSlot) variable).getValue());
+            }
+            atm.addAnnotation(slotManager.getAnnotation(variable));
         } else {
             AnnotationLocation location = treeToLocation(tree);
             variable = replaceOrCreateEquivalentVarAnno(atm, tree, location);
@@ -509,9 +513,6 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
             treeToVarAnnoPair.put(tree, varATMPair);
         }
-
-        atm.replaceAnnotation(slotManager.getAnnotation(variable));
-
         return variable;
     }
 
@@ -566,8 +567,10 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         } else {
             varSlot = createVariable(location);
         }
-
-        atm.replaceAnnotation(slotManager.getAnnotation(varSlot));
+        if (realQualifier != null) {
+        	atm.removeAnnotation(realQualifier);
+        }
+        atm.addAnnotation(slotManager.getAnnotation(varSlot));
         return varSlot;
     }
 

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -503,7 +503,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             if (variable instanceof ConstantSlot) {
             	atm.removeAnnotation(((ConstantSlot) variable).getValue());
             }
-            atm.addAnnotation(slotManager.getAnnotation(variable));
+            atm.replaceAnnotation(slotManager.getAnnotation(variable));
         } else {
             AnnotationLocation location = treeToLocation(tree);
             variable = replaceOrCreateEquivalentVarAnno(atm, tree, location);
@@ -570,7 +570,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         if (realQualifier != null) {
         	atm.removeAnnotation(realQualifier);
         }
-        atm.addAnnotation(slotManager.getAnnotation(varSlot));
+        atm.replaceAnnotation(slotManager.getAnnotation(varSlot));
         return varSlot;
     }
 


### PR DESCRIPTION
Currently CFI does not properly handle it when adding variable annotations. Notice that `VarAnnot` and real annotations are treated differently by `InferenceQualifierHierarchy#findAnnotationInSameHierarchy` and `InferenceQualifierHierarchy#findAnnotationInHierarchy`, while considered to be in the same qualifier hierarchy.

In this case, calling `replaceAnnotation` (which uses `findAnnotationInSameHierarchy` to fetch and remove existing annotations of the same hierarchy) attempting to replace a real annotation with a variable annotation does not work as intended, and it will add the variable annotation with the original annotation left intact, resulting in conflicting annotations.

This pull request is currently only a partial fix and serves as an example of such issues, as there are other places where similar issues are expected to arise, given our experience experimenting on PICO inference. Whenever CFI crashes with a "conflicting annotations" exception between real annotations and variable annotations (or between variable annotations and variable annotations) being raised, it is possible to be a similar problem to the ones illustrated here.

CFI master currently does not have such problems because conflicting annotations check is temporarily disabled (among others), but customized checkers like GUT and PICO could suffer from it.