### PR TITLE
Add glb override to InferenceQualifierHierarchy

### DIFF
--- a/src/checkers/inference/InferenceQualifierHierarchy.java
+++ b/src/checkers/inference/InferenceQualifierHierarchy.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
+
+import checkers.inference.model.AnnotationLocation;
 import checkers.inference.model.ConstantSlot;
 import checkers.inference.model.ConstraintManager;
 import checkers.inference.model.Slot;
@@ -290,6 +292,75 @@ public class InferenceQualifierHierarchy extends MultiGraphQualifierHierarchy {
 
                     var1.addMergedToSlot(mergeVariableSlot);
                     var2.addMergedToSlot(mergeVariableSlot);
+
+                    return slotMgr.getAnnotation(mergeVariableSlot);
+                }
+            }
+        } else {
+            return slotMgr.getAnnotation(slot1);
+        }
+    }
+    
+    @Override
+    public AnnotationMirror greatestLowerBound(final AnnotationMirror a1, final AnnotationMirror a2) {
+        if (InferenceMain.isHackMode( (a1 == null || a2 == null))) {
+            InferenceMain.getInstance().logger.info(
+                    "Hack:\n"
+                  + "a1=" + a1 + "\n"
+                  + "a2=" + a2);
+            return a1 != null ? a1 : a2;
+        }
+        assert a1 != null && a2 != null : "greatestLowerBound accepts only NonNull types! 1 (" + a1 + " ) a2 (" + a2 + ")";
+
+        QualifierHierarchy realQualifierHierarhcy = inferenceMain.getRealTypeFactory().getQualifierHierarchy();
+        // for some reason GLB compares all annotations even if they are not in the same sub-hierarchy
+        if (!isVarAnnot(a1)) {
+            if (!isVarAnnot(a2)) {
+                return inferenceMain.getRealTypeFactory().getQualifierHierarchy().greatestLowerBound(a1, a2);
+            } else {
+                return null;
+            }
+        } else if (!isVarAnnot(a2)) {
+            return null;
+        }
+
+        // TODO: How to get the path to the CombVariable?
+        final Slot slot1 = slotMgr.getSlot(a1);
+        final Slot slot2 = slotMgr.getSlot(a2);
+        if (slot1 != slot2) {
+            if ((slot1 instanceof ConstantSlot) && (slot2 instanceof ConstantSlot)) {
+                // If both slots are constant slots, using real qualifier hierarchy to compute the GLB,
+                // then return a VarAnnot represent the constant GLB.
+                // (Because we passing in two VarAnnots that represent constant slots, so it is consistent
+                // to also return a VarAnnot that represents the constant GLB of these two constants.)
+                AnnotationMirror realAnno1 = ((ConstantSlot) slot1).getValue();
+                AnnotationMirror realAnno2 = ((ConstantSlot) slot2).getValue();
+
+                AnnotationMirror realLub = realQualifierHierarhcy.greatestLowerBound(realAnno1, realAnno2);
+                Slot constantSlot = slotMgr.createConstantSlot(realLub);
+                return slotMgr.getAnnotation(constantSlot);
+            } else {
+                VariableSlot var1 = (VariableSlot) slot1;
+                VariableSlot var2 = (VariableSlot) slot2;
+
+                if (var1 == var2) {
+                    // They are the same slot.
+                    return slotMgr.getAnnotation(var1);
+
+                } else if (var1.isMergedTo(var2)) {
+                    // var2 is a merge variable that var1 has been merged to. So just return annotation on var1.
+                    return slotMgr.getAnnotation(var1);
+                } else if (var2.isMergedTo(var1)) {
+                    // Vice versa.
+                    return slotMgr.getAnnotation(var2);
+                } else {
+                    // Create a new LubVariable for var1 and var2.
+                    final VariableSlot mergeVariableSlot = slotMgr.createVariableSlot(AnnotationLocation.MISSING_LOCATION);
+                    constraintMgr.addSubtypeConstraint(mergeVariableSlot, var1);
+                    constraintMgr.addSubtypeConstraint(mergeVariableSlot, var2);
+
+//                    mergeVariableSlot.addMergedToSlot(var1);
+//                    mergeVariableSlot.addMergedToSlot(var2);
 
                     return slotMgr.getAnnotation(mergeVariableSlot);
                 }


### PR DESCRIPTION
This pull request adds an override of `greatestLowerBound` to `InferenceQualifierHierarchy` which now creates two subtype constraints when computing the greatest lower bound of two variable annotations. Prior to this change, a crash in CFI can be observed when inference is run on the following test code:
```
import java.util.Set;

class GlbCrash {
        Set<?> foo;
        Set<?> bar;
        Set crash() {
                return true ? foo : bar;
        }
}
```
For instance, if we run `./inference --checker universe.GUTChecker --solver checkers.inference.solver.DebugSolver --solverArgs=useGraph=false,collectStatistic=true --hacks=true -afud /home/multipass/annotated -m ROUNDTRIP ~/GlbCrash.java` which runs GUT inference on the test code shown above, we will see the following:
```
error: Create subtype constraint with null argument. Subtype: null Supertype: LubVariableSlot(31)
  Compilation unit: /home/multipass/GlbCrash.java
  Last visited tree at line 7 column 17:
  		return true ? foo : bar;
  Exception: java.lang.Throwable; Stack trace: org.checkerframework.javacutil.BugInCF.<init>(BugInCF.java:14)
  checkers.inference.model.SubtypeConstraint.create(SubtypeConstraint.java:51)
  checkers.inference.model.ConstraintManager.createSubtypeConstraint(ConstraintManager.java:94)
  checkers.inference.model.ConstraintManager.addSubtypeConstraintNoErrorMsg(ConstraintManager.java:199)
  checkers.inference.InferenceQualifierHierarchy.isSubtype(InferenceQualifierHierarchy.java:227)
  checkers.inference.InferenceQualifierHierarchy.isSubtype(InferenceQualifierHierarchy.java:207)
  org.checkerframework.common.basetype.BaseTypeValidator.areBoundsValid(BaseTypeValidator.java:469)
  org.checkerframework.common.basetype.BaseTypeValidator.visitWildcard(BaseTypeValidator.java:450)
  org.checkerframework.common.basetype.BaseTypeValidator.visitWildcard(BaseTypeValidator.java:1)
  org.checkerframework.framework.type.AnnotatedTypeMirror$AnnotatedWildcardType.accept(AnnotatedTypeMirror.java:1890)
  org.checkerframework.framework.type.visitor.AnnotatedTypeScanner.scan(AnnotatedTypeScanner.java:103)
  org.checkerframework.framework.type.visitor.AnnotatedTypeScanner.scan(AnnotatedTypeScanner.java:120)
  org.checkerframework.framework.type.visitor.AnnotatedTypeScanner.scanAndReduce(AnnotatedTypeScanner.java:127)
  org.checkerframework.framework.type.visitor.AnnotatedTypeScanner.visitDeclared(AnnotatedTypeScanner.java:170)
  org.checkerframework.common.basetype.BaseTypeValidator.visitDeclared(BaseTypeValidator.java:248)
  universe.GUTValidator.visitDeclared(GUTValidator.java:50)
  org.checkerframework.common.basetype.BaseTypeValidator.visitDeclared(BaseTypeValidator.java:1)
  org.checkerframework.framework.type.AnnotatedTypeMirror$AnnotatedDeclaredType.accept(AnnotatedTypeMirror.java:848)
  org.checkerframework.framework.type.visitor.AnnotatedTypeScanner.scan(AnnotatedTypeScanner.java:103)
  org.checkerframework.framework.type.visitor.AnnotatedTypeScanner.visit(AnnotatedTypeScanner.java:91)
  org.checkerframework.common.basetype.BaseTypeValidator.isValid(BaseTypeValidator.java:70)
  universe.GUTVisitor.validateType(GUTVisitor.java:418)
  universe.GUTVisitor.validateTypeOf(GUTVisitor.java:411)
  org.checkerframework.common.basetype.BaseTypeVisitor.commonAssignmentCheck(BaseTypeVisitor.java:2204)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitReturn(BaseTypeVisitor.java:1638)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitReturn(BaseTypeVisitor.java:1)
  com.sun.tools.javac.tree.JCTree$JCReturn.accept(JCTree.java:1390)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:68)
  org.checkerframework.framework.source.SourceVisitor.scan(SourceVisitor.java:88)
  org.checkerframework.common.basetype.BaseTypeVisitor.scan(BaseTypeVisitor.java:301)
  org.checkerframework.common.basetype.BaseTypeVisitor.scan(BaseTypeVisitor.java:1)
  com.sun.source.util.TreeScanner.scan(TreeScanner.java:91)
  com.sun.source.util.TreeScanner.visitBlock(TreeScanner.java:162)
  com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:918)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:68)
  org.checkerframework.framework.source.SourceVisitor.scan(SourceVisitor.java:88)
  org.checkerframework.common.basetype.BaseTypeVisitor.scan(BaseTypeVisitor.java:301)
  org.checkerframework.common.basetype.BaseTypeVisitor.scan(BaseTypeVisitor.java:1)
  com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:81)
  com.sun.source.util.TreeScanner.visitMethod(TreeScanner.java:144)
  org.checkerframework.framework.source.SourceVisitor.visitMethod(SourceVisitor.java:106)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitMethod(BaseTypeVisitor.java:683)
  universe.GUTVisitor.visitMethod(GUTVisitor.java:138)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitMethod(BaseTypeVisitor.java:1)
  com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:800)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:68)
  org.checkerframework.framework.source.SourceVisitor.scan(SourceVisitor.java:88)
  org.checkerframework.common.basetype.BaseTypeVisitor.scan(BaseTypeVisitor.java:301)
  org.checkerframework.common.basetype.BaseTypeVisitor.scan(BaseTypeVisitor.java:1)
  com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:81)
  com.sun.source.util.TreeScanner.scan(TreeScanner.java:91)
  com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:99)
  com.sun.source.util.TreeScanner.visitClass(TreeScanner.java:133)
  org.checkerframework.framework.source.SourceVisitor.visitClass(SourceVisitor.java:94)
  org.checkerframework.common.basetype.BaseTypeVisitor.processClassTree(BaseTypeVisitor.java:384)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:339)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:1)
  com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:720)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:50)
  org.checkerframework.framework.source.SourceVisitor.visit(SourceVisitor.java:82)
  org.checkerframework.framework.source.SourceChecker.typeProcess(SourceChecker.java:1008)
  org.checkerframework.common.basetype.BaseTypeChecker.typeProcess(BaseTypeChecker.java:522)
  org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:182)
  com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:681)
  com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:111)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1342)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1296)
  com.sun.tools.javac.main.JavaCompiler.compile2(JavaCompiler.java:901)
  com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:860)
  com.sun.tools.javac.main.Main.compile(Main.java:523)
  com.sun.tools.javac.main.Main.compile(Main.java:381)
  com.sun.tools.javac.main.Main.compile(Main.java:370)
  com.sun.tools.javac.main.Main.compile(Main.java:361)
  checkers.inference.CheckerFrameworkUtil.invokeCheckerFramework(CheckerFrameworkUtil.java:12)
  checkers.inference.InferenceMain.startCheckerFramework(InferenceMain.java:191)
  checkers.inference.InferenceMain.run(InferenceMain.java:145)
  checkers.inference.InferenceMain.main(InferenceMain.java:117)
1 error
```

The reason we are having this problem is that, since `foo` and `bar` are both declared wildcard types `Set<?>`, they implicitly have a lower bound and an upper bound respectively, which will all be annotated with some variable annotations during inference. When checking the type of the ternary expression `true ? foo : bar`, however, CFI attempts to find the LUB of the types of `foo` and `bar`, which further involves computing the GLB of their respective lower bounds (this behaviour is implemented in `AtmLubVisitor#lubWildcard`). In the absence of a GLB override in `InferenceQualifierHierarchy`, `MultiGraphQualifierHierarchy#greatestLowerBound` is invoked and will produce a variable annotation with an empty `elementValues` field, resulting in the ternary expression being typed with a lower bound annotated with `@VarAnnot` (without element). This will cause problems when CF validates the type, since it checks whether the lower bound is a subtype of the upper bounds, resulting in the crash depicted in the above stack trace.

We currently have no way to replicate this in checkers that come with CFI master because type validation in CFI is disabled to mitigate some bugs. Customized checkers like GUT and PICO could suffer from this, though, because they override and re-enable those validations.

The implementation of GLB provided in this pull request follows the same logic of which `InferenceQualifierHierarchy#leastUpperBound` handles variable annotations, but it does not keep track of merged variables created using this method, because current implementation of variable annotation can only track merged variables from LUB.