### PR TITLE
Fix buildZ3 double brackets not found

### DIFF
--- a/scripts/buildZ3
+++ b/scripts/buildZ3
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Fail the whole script if any command fails
 set -e


### PR DESCRIPTION
Hello, this PR fixes a simple error. 

When buildZ3 is called, there will be an error which is because that `[[ ]]` is only supported in bash. Since we do not specify  `/bin/bash` but using `/bin/sh`, this error occurs. 

The error info is in [here](https://travis-ci.org/opprop/checker-framework/jobs/532566064#L1418). 