### PR TITLE
Remove usages of getTypeQualifiers()

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -119,11 +119,8 @@ public class DefaultSlotManager implements SlotManager {
         arithmeticSlotCache = new LinkedHashMap<>();
 
         if (storeConstants) {
-            Set<Class<? extends Annotation>> annoClasses =
-                    InferenceMain.getInstance().getRealTypeFactory().getSupportedTypeQualifiers();
-            for (Class<? extends Annotation> ac : annoClasses) {
-                AnnotationMirror am = AnnotationBuilder.fromClass(
-                        processingEnvironment.getElementUtils(), ac);
+            for (Class<? extends Annotation> annoClass : this.realQualifiers) {
+                AnnotationMirror am = new AnnotationBuilder(processingEnvironment, annoClass).build();
                 ConstantSlot constantSlot = new ConstantSlot(am, nextId());
                 addToVariables(constantSlot);
                 constantCache.put(am, constantSlot.getId());

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -119,9 +119,11 @@ public class DefaultSlotManager implements SlotManager {
         arithmeticSlotCache = new LinkedHashMap<>();
 
         if (storeConstants) {
-            @SuppressWarnings("deprecation") // replace getTypeQualifiers
-            Set<? extends AnnotationMirror> mirrors = InferenceMain.getInstance().getRealTypeFactory().getQualifierHierarchy().getTypeQualifiers();
-            for (AnnotationMirror am : mirrors) {
+            Set<Class<? extends Annotation>> annoClasses =
+                    InferenceMain.getInstance().getRealTypeFactory().getSupportedTypeQualifiers();
+            for (Class<? extends Annotation> ac : annoClasses) {
+                AnnotationMirror am = AnnotationBuilder.fromClass(
+                        processingEnvironment.getElementUtils(), ac);
                 ConstantSlot constantSlot = new ConstantSlot(am, nextId());
                 addToVariables(constantSlot);
                 constantCache.put(am, constantSlot.getId());

--- a/src/checkers/inference/solver/frontend/LatticeBuilder.java
+++ b/src/checkers/inference/solver/frontend/LatticeBuilder.java
@@ -76,7 +76,6 @@ public class LatticeBuilder {
      * @param qualHierarchy of underling type system.
      * @return a new Lattice instance.
      */
-    @SuppressWarnings("deprecation") // replace getTypeQualifiers
     public Lattice buildLattice(QualifierHierarchy qualHierarchy, Collection<Slot> slots) {
         clear();
 
@@ -88,9 +87,13 @@ public class LatticeBuilder {
                     InferenceMain.getInstance().getRealTypeFactory().getElementUtils(), ac));
         }
 
-        allTypes = supportedAnnos;
         top = qualHierarchy.getTopAnnotations().iterator().next();
         bottom = qualHierarchy.getBottomAnnotations().iterator().next();
+
+        // TODO this is a workaround for "computed" bottoms. e.g. DataFlow bottom
+        supportedAnnos.add(bottom);  // this is a set: existing bottom will not added twice
+        allTypes = supportedAnnos;
+
         numTypes = supportedAnnos.size();
 
         // Calculate subtypes map and supertypes map

--- a/src/checkers/inference/solver/frontend/LatticeBuilder.java
+++ b/src/checkers/inference/solver/frontend/LatticeBuilder.java
@@ -38,6 +38,7 @@ public class LatticeBuilder {
      * All type qualifiers in underling type system.
      * Requires annotation ordering, so must created with {@code AnnotationUtils.createAnnotationSet()} when constructing from empty set,
      * even if being converted to {@code UnmodifiableSet} later on
+     * TODO remove the dependency to TreeSet
      */
     private Set<? extends AnnotationMirror> allTypes;
 

--- a/src/checkers/inference/solver/frontend/LatticeBuilder.java
+++ b/src/checkers/inference/solver/frontend/LatticeBuilder.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
 
+import checkers.inference.InferenceMain;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;

--- a/src/checkers/inference/solver/frontend/LatticeBuilder.java
+++ b/src/checkers/inference/solver/frontend/LatticeBuilder.java
@@ -36,6 +36,8 @@ public class LatticeBuilder {
 
     /**
      * All type qualifiers in underling type system.
+     * Requires annotation ordering, so must created with {@code AnnotationUtils.createAnnotationSet()} when constructing from empty set,
+     * even if being converted to {@code UnmodifiableSet} later on
      */
     private Set<? extends AnnotationMirror> allTypes;
 

--- a/src/checkers/inference/solver/frontend/LatticeBuilder.java
+++ b/src/checkers/inference/solver/frontend/LatticeBuilder.java
@@ -1,5 +1,6 @@
 package checkers.inference.solver.frontend;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -9,6 +10,7 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 
 import org.checkerframework.framework.type.QualifierHierarchy;
+import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 
 import checkers.inference.model.ConstantSlot;
@@ -76,10 +78,19 @@ public class LatticeBuilder {
     @SuppressWarnings("deprecation") // replace getTypeQualifiers
     public Lattice buildLattice(QualifierHierarchy qualHierarchy, Collection<Slot> slots) {
         clear();
-        allTypes = qualHierarchy.getTypeQualifiers();
+
+        Set<AnnotationMirror> supportedAnnos = new HashSet<>();
+        Set<Class<? extends Annotation>> annoClasses =
+                InferenceMain.getInstance().getRealTypeFactory().getSupportedTypeQualifiers();
+        for (Class<? extends Annotation> ac: annoClasses) {
+            supportedAnnos.add(AnnotationBuilder.fromClass(
+                    InferenceMain.getInstance().getRealTypeFactory().getElementUtils(), ac));
+        }
+
+        allTypes = supportedAnnos;
         top = qualHierarchy.getTopAnnotations().iterator().next();
         bottom = qualHierarchy.getBottomAnnotations().iterator().next();
-        numTypes = qualHierarchy.getTypeQualifiers().size();
+        numTypes = supportedAnnos.size();
 
         // Calculate subtypes map and supertypes map
         for (AnnotationMirror i : allTypes) {


### PR DESCRIPTION
Since `getTypeQualifiers()` is finally removed in typetools/CF, the usages are all replaced with real type factory's `getSupportedTypeQualifiers()`