### PR TITLE
Fix NPE error on class declaration.

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -568,13 +568,8 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         return withCombineConstraints ? new InferenceViewpointAdapter(this) : null;
     }
 
-    /**
-     * Get the real top annotation from {@link #realTypeFactory}.
-     * @return the real top annotation.
-     */
     @Override
     protected Set<? extends AnnotationMirror> getDefaultTypeDeclarationBounds() {
-        return realTypeFactory.getQualifierHierarchy().getTopAnnotations();
+        return this.getQualifierHierarchy().getTopAnnotations();
     }
 }
-


### PR DESCRIPTION
This PR makes the `getDefaultTypeDeclarationBounds()` return `VarAnnot()` instead of the real annotation to avoid crash in `isSubtype()`.