### PR TITLE
Handle jaif for constructor with empty ASTPath

### DIFF
--- a/src/checkers/inference/util/ASTPathUtil.java
+++ b/src/checkers/inference/util/ASTPathUtil.java
@@ -74,7 +74,11 @@ public class ASTPathUtil {
      * this class.
      */
     public static ASTRecord getConstructorRecord(ASTRecord classRecord) {
-        return new ASTRecord(classRecord.ast, classRecord.className, AFU_CONSTRUCTOR_ID, null, ASTPath.empty());
+        return new ASTRecord(classRecord.ast, classRecord.className, AFU_CONSTRUCTOR_ID, null, getMethodTypeASTPath());
+    }
+
+    public static ASTPath getMethodTypeASTPath() {
+        return ASTPath.empty().extend(new ASTPath.ASTEntry(Tree.Kind.METHOD, ASTPath.TYPE, null));
     }
 
     /**

--- a/src/checkers/inference/util/JaifBuilder.java
+++ b/src/checkers/inference/util/JaifBuilder.java
@@ -310,7 +310,12 @@ public class JaifBuilder {
                     // TODO: this is not a feature but a workaround of a bug:
                     // We should create a non-empty correct ASTPath for constructor
                     if (astRecord.astPath.equals(ASTPath.empty())) {
-                        continue;
+                        if (astRecord.methodName != null && astRecord.methodName.contains("<init>")) {
+                            astRecord = new ASTRecord(astRecord.ast, astRecord.className,
+                                    astRecord.methodName, astRecord.varName, ASTPathUtil.getMethodTypeASTPath());
+                        } else {
+                            continue;
+                        }
                     }
 
                     memberRecords.entries.add(new RecordValue(astRecord.astPath,annotation));


### PR DESCRIPTION
Jaif writer skips records with empty `ASTPath` but constructor records are created with an empty path thus get skipped.
Updating this behaviour will allow injecting infereed annotations to constructors by including these records into generated jaif file.