### PR TITLE
Disable fail-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         group: [ cfi-tests, downstream-ontology, downstream-security-demo ]
         jdk: [ 8, 11 ]


### PR DESCRIPTION
So the CI runs through, instead of terminating at the first failure.