### PR TITLE
Cache refinement in dataflow for use in commonAssignmentCheck

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -124,6 +124,12 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     // the same variable slot for all of these locations.  This map contains those variables.
     private Map<Class<? extends Annotation>, VariableSlot> constantToVarAnnot = new HashMap<>();
 
+    /**
+     * This field caches the mappings from lhs tree of an assignment to the corresponding
+     * annotated type after refinement.
+     */
+    private final Map<Tree, AnnotatedTypeMirror> treeToRefinedType = new HashMap<>();
+
     public InferenceAnnotatedTypeFactory(
             InferenceChecker inferenceChecker,
             boolean withCombineConstraints,
@@ -575,6 +581,29 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     protected Set<? extends AnnotationMirror> getDefaultTypeDeclarationBounds() {
         return realTypeFactory.getQualifierHierarchy().getTopAnnotations();
+    }
+
+    /**
+     * Gets the refined type of the lhs tree (of an assignment)
+     * @param node
+     * @return
+     */
+    public AnnotatedTypeMirror getRefinedTypeForTree(Tree node) {
+        if (node != null) {
+            return treeToRefinedType.get(node);
+        }
+        return null;
+    }
+
+    /**
+     * Caches the refined type of the lhs tree (of an assignment)
+     * @param node
+     * @param atm
+     */
+    public void cacheRefinedTypeForTree(Tree node, AnnotatedTypeMirror atm) {
+        if (node != null && treeToRefinedType.containsKey(node)) {
+            treeToRefinedType.put(node, atm);
+        }
     }
 }
 

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -464,7 +464,12 @@ public class InferenceVisitor<Checker extends InferenceChecker,
         // Refinement variables come from flow inference, so we need to call getAnnotatedType instead of getDefaultedAnnotatedType
         AnnotatedTypeMirror var;
         if (this.infer) {
-            var = atypeFactory.getAnnotatedType(varTree);
+            // Instead of the LHS's annotated type, get the annotated type after refinement,
+            // which was cached during dataflow analysis.
+            var = ((InferenceAnnotatedTypeFactory)atypeFactory).getRefinedTypeForTree(varTree);
+            if (var == null) {
+                var = atypeFactory.getAnnotatedType(varTree);
+            }
         } else {
             var = atypeFactory.getAnnotatedTypeLhs(varTree);
         }


### PR DESCRIPTION
Currently, the CFI dataflow transfer function overrides the LHS's node value with the refinement variable, a misleading and error-prone trick for the convenience of creating equality constraint in `CommonAssignmentCheck`.

