### PR TITLE
Adapt flow refinement in inference

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -318,22 +318,22 @@ public class DefaultSlotManager implements SlotManager {
     }
 
     @Override
-    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined, Slot refineTo) {
+    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot declaredTypeSlot, Slot valueSlot) {
         RefinementVariableSlot refinementVariableSlot;
         if (location.getKind() == AnnotationLocation.Kind.MISSING) {
             //Don't cache slot for MISSING LOCATION. Just create a new one and return.
-            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), refined);
-            if (refineTo != null) {
-                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, refineTo);
+            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), declaredTypeSlot);
+            if (valueSlot != null) {
+                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
             }
             addToVariables(refinementVariableSlot);
         } else if (locationCache.containsKey(location)) {
             int id = locationCache.get(location);
             refinementVariableSlot = (RefinementVariableSlot) getVariable(id);
         } else {
-            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), refined);
-            if (refineTo != null) {
-                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, refineTo);
+            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), declaredTypeSlot);
+            if (valueSlot != null) {
+                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
             }
             addToVariables(refinementVariableSlot);
             locationCache.put(location, refinementVariableSlot.getId());

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -318,8 +318,7 @@ public class DefaultSlotManager implements SlotManager {
     }
 
     @Override
-    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot delarationSlot, Slot valueSlot) {
-        RefinementVariableSlot refinementVariableSlot;
+    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot declarationSlot, Slot valueSlot) {
         // If the location is already cached, return the corresponding refinement slot in the cache
         if (locationCache.containsKey(location)) {
             int id = locationCache.get(location);
@@ -327,13 +326,17 @@ public class DefaultSlotManager implements SlotManager {
         }
 
         // Create new refinement variable slot, as well as the equality constraint to the value slot
-        refinementVariableSlot = new RefinementVariableSlot(location, nextId(), delarationSlot);
+        RefinementVariableSlot refinementVariableSlot;
+        refinementVariableSlot = new RefinementVariableSlot(location, nextId(), declarationSlot);
+        addToVariables(refinementVariableSlot);
         if (valueSlot != null) {
+            // If the rhs value slot passed in is non-null, create the equality constraint on it
             InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
         }
-        addToVariables(refinementVariableSlot);
 
         // Only cache slot for non-MISSING LOCATION
+        // TODO: We should always create refinement variable on a non-missing location,
+        //  and remove this if-condition
         if (location.getKind() != AnnotationLocation.Kind.MISSING) {
             locationCache.put(location, refinementVariableSlot.getId());
         }

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -318,17 +318,23 @@ public class DefaultSlotManager implements SlotManager {
     }
 
     @Override
-    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined) {
+    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined, Slot refineTo) {
         RefinementVariableSlot refinementVariableSlot;
         if (location.getKind() == AnnotationLocation.Kind.MISSING) {
             //Don't cache slot for MISSING LOCATION. Just create a new one and return.
             refinementVariableSlot = new RefinementVariableSlot(location, nextId(), refined);
+            if (refineTo != null) {
+                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, refineTo);
+            }
             addToVariables(refinementVariableSlot);
         } else if (locationCache.containsKey(location)) {
             int id = locationCache.get(location);
             refinementVariableSlot = (RefinementVariableSlot) getVariable(id);
         } else {
             refinementVariableSlot = new RefinementVariableSlot(location, nextId(), refined);
+            if (refineTo != null) {
+                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, refineTo);
+            }
             addToVariables(refinementVariableSlot);
             locationCache.put(location, refinementVariableSlot.getId());
         }

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -318,11 +318,11 @@ public class DefaultSlotManager implements SlotManager {
     }
 
     @Override
-    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot declaredTypeSlot, Slot valueSlot) {
+    public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot delarationSlot, Slot valueSlot) {
         RefinementVariableSlot refinementVariableSlot;
         if (location.getKind() == AnnotationLocation.Kind.MISSING) {
             //Don't cache slot for MISSING LOCATION. Just create a new one and return.
-            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), declaredTypeSlot);
+            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), delarationSlot);
             if (valueSlot != null) {
                 InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
             }
@@ -331,7 +331,7 @@ public class DefaultSlotManager implements SlotManager {
             int id = locationCache.get(location);
             refinementVariableSlot = (RefinementVariableSlot) getVariable(id);
         } else {
-            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), declaredTypeSlot);
+            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), delarationSlot);
             if (valueSlot != null) {
                 InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
             }

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -320,22 +320,21 @@ public class DefaultSlotManager implements SlotManager {
     @Override
     public RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot delarationSlot, Slot valueSlot) {
         RefinementVariableSlot refinementVariableSlot;
-        if (location.getKind() == AnnotationLocation.Kind.MISSING) {
-            //Don't cache slot for MISSING LOCATION. Just create a new one and return.
-            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), delarationSlot);
-            if (valueSlot != null) {
-                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
-            }
-            addToVariables(refinementVariableSlot);
-        } else if (locationCache.containsKey(location)) {
+        // If the location is already cached, return the corresponding refinement slot in the cache
+        if (locationCache.containsKey(location)) {
             int id = locationCache.get(location);
-            refinementVariableSlot = (RefinementVariableSlot) getVariable(id);
-        } else {
-            refinementVariableSlot = new RefinementVariableSlot(location, nextId(), delarationSlot);
-            if (valueSlot != null) {
-                InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
-            }
-            addToVariables(refinementVariableSlot);
+            return (RefinementVariableSlot) getVariable(id);
+        }
+
+        // Create new refinement variable slot, as well as the equality constraint to the value slot
+        refinementVariableSlot = new RefinementVariableSlot(location, nextId(), delarationSlot);
+        if (valueSlot != null) {
+            InferenceMain.getInstance().getConstraintManager().addEqualityConstraint(refinementVariableSlot, valueSlot);
+        }
+        addToVariables(refinementVariableSlot);
+
+        // Only cache slot for non-MISSING LOCATION
+        if (location.getKind() != AnnotationLocation.Kind.MISSING) {
             locationCache.put(location, refinementVariableSlot.getId());
         }
         return refinementVariableSlot;

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -584,9 +584,8 @@ public class InferenceVisitor<Checker extends InferenceChecker,
      * For declared type, we create the refinement constraint once the refinement variable is created in 
      * {@link checkers.inference.dataflow.InferenceTransfer#createRefinementVar} during dataflow analysis.
      * Therefore nothing needs to be done here.
-     * TODO: handle the type variable the same way as declared type, so that finally all refinement-related
-     * constraints are created in the dataflow analysis, and this method is removed.
-     * TODO: RECONSIDER THIS WHEN WE CONSIDER WILDCARDS
+     * TODO: handle type variables and wildcards the same way as declared types, so that finally all 
+     * refinement-related constraints are created in the dataflow analysis, and this method is removed.
      */
     public boolean maybeAddRefinementVariableConstraints(final AnnotatedTypeMirror varType, final AnnotatedTypeMirror valueType) {
         boolean inferenceRefinementVariable = false;

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -580,6 +580,11 @@ public class InferenceVisitor<Checker extends InferenceChecker,
      * pseudo-assignment that created it.
      *
      * This method detects the assignments that cause refinements and generates the above constraints.
+     *
+     * For declared type, we create the refinement constraint once the refinement variable is created
+     * during dataflow analysis. Therefore nothing needs to be done here.
+     * TODO: handle the type variable the same way as declared type, so that finally all refinement-related
+     * constraints are created in the dataflow analysis, and this method is useless.
      */
     public boolean maybeAddRefinementVariableConstraints(final AnnotatedTypeMirror varType, final AnnotatedTypeMirror valueType) {
         boolean inferenceRefinementVariable = false;
@@ -641,11 +646,9 @@ public class InferenceVisitor<Checker extends InferenceChecker,
                     // TODO: OR A DIFFERENT SET OF CONSTRAINTS?
                 }
             }
-        } else {
-            // TODO: RECONSIDER THIS WHEN WE CONSIDER WILDCARDS
-            if (varType.getKind() == TypeKind.WILDCARD) {
-            }
         }
+
+        // TODO: RECONSIDER THIS WHEN WE CONSIDER WILDCARDS
 
         return inferenceRefinementVariable;
     }

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -642,30 +642,8 @@ public class InferenceVisitor<Checker extends InferenceChecker,
                 }
             }
         } else {
-
             // TODO: RECONSIDER THIS WHEN WE CONSIDER WILDCARDS
-            if (varType.getKind() != TypeKind.WILDCARD) {
-                Slot sup = InferenceMain.getInstance().getSlotManager().getVariableSlot(varType);
-                if (sup instanceof RefinementVariableSlot && !InferenceMain.getInstance().isPerformingFlow()) {
-                    inferenceRefinementVariable = true;
-
-                    final AnnotatedTypeMirror upperBound;
-                    if (valueType.getKind() == TypeKind.TYPEVAR) {
-                        upperBound = InferenceUtil.findUpperBoundType((AnnotatedTypeVariable) valueType);
-                    } else {
-                        upperBound = valueType;
-                    }
-
-                    Slot sub = slotManager.getVariableSlot(upperBound);
-                    logger.fine("InferenceVisitor::commonAssignmentCheck: Equality constraint for qualifiers sub: " + sub + " sup: " + sup);
-
-                    // Equality between the refvar and the value
-                    constraintManager.addEqualityConstraint(sup, sub);
-
-                    // Refinement variable still needs to be a subtype of its declared type value
-                    constraintManager.addSubtypeConstraint(sup,
-                            ((RefinementVariableSlot) sup).getRefined());
-                }
+            if (varType.getKind() == TypeKind.WILDCARD) {
             }
         }
 

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -581,10 +581,12 @@ public class InferenceVisitor<Checker extends InferenceChecker,
      *
      * This method detects the assignments that cause refinements and generates the above constraints.
      *
-     * For declared type, we create the refinement constraint once the refinement variable is created
-     * during dataflow analysis. Therefore nothing needs to be done here.
+     * For declared type, we create the refinement constraint once the refinement variable is created in 
+     * {@link checkers.inference.dataflow.InferenceTransfer#createRefinementVar} during dataflow analysis.
+     * Therefore nothing needs to be done here.
      * TODO: handle the type variable the same way as declared type, so that finally all refinement-related
-     * constraints are created in the dataflow analysis, and this method is useless.
+     * constraints are created in the dataflow analysis, and this method is removed.
+     * TODO: RECONSIDER THIS WHEN WE CONSIDER WILDCARDS
      */
     public boolean maybeAddRefinementVariableConstraints(final AnnotatedTypeMirror varType, final AnnotatedTypeMirror valueType) {
         boolean inferenceRefinementVariable = false;
@@ -647,8 +649,6 @@ public class InferenceVisitor<Checker extends InferenceChecker,
                 }
             }
         }
-
-        // TODO: RECONSIDER THIS WHEN WE CONSIDER WILDCARDS
 
         return inferenceRefinementVariable;
     }

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -54,7 +54,7 @@ public interface SlotManager {
      *            a potential downward refinement of an existing VariableSlot
      * @return RefinementVariableSlot that corresponds to this location
      */
-    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined);
+    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined, Slot refineTo);
 
     /**
      * Create new ConstrantSlot and returns the reference to it if no

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -57,6 +57,9 @@ public interface SlotManager {
      *            non-null, an equality constraint "delarationSlot == valueSlot" is
      *            created. Otherwise such constraint is created in
      *            {@link InferenceVisitor#maybeAddRefinementVariableConstraints}
+     *            Now we pass in non-null valueSlot only when lhs is declared type.
+     *            TODO: handle wildcards/type variables in the same way as declared
+     *            type, so that this parameter is always non-null
      *
      * @return RefinementVariableSlot that corresponds to this refinement
      */

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -43,22 +43,24 @@ public interface SlotManager {
     VariableSlot createVariableSlot(AnnotationLocation location);
 
     /**
-     * Create new RefinementVariableSlot and return the reference to it if no
-     * RefinementVariableSlot on this location exists. Otherwise return the
-     * reference to existing RefinementVariableSlot on this location. Each
-     * location uniquely identifies a RefinementVariableSlot
-     *
-     * Create the related equality constraint if the refinement value is given.
+     * Create new RefinementVariableSlot (as well as the refinement constraint if
+     * possible) and return the reference to it if no RefinementVariableSlot on this
+     * location exists. Otherwise return the reference to existing RefinementVariableSlot
+     * on this location. Each location uniquely identifies a RefinementVariableSlot
      *
      * @param location
-     *            used to locate this variable in code.
-     * @param declaredTypeSlot
-     *            a potential downward refinement of an existing VariableSlot
+     *            used to locate this refinement variable in code
+     * @param delarationSlot
+     *            the VariableSlot for the lhs that gets refined
      * @param valueSlot
-     *            the lhs value the existing VariableSlot is refined to
-     * @return RefinementVariableSlot that corresponds to this location
+     *            the value that the given lhs VariableSlot is refined to. If it is
+     *            non-null, an equality constraint "delarationSlot == valueSlot" is
+     *            created. Otherwise such constraint is created in
+     *            {@link InferenceVisitor#maybeAddRefinementVariableConstraints}
+     *
+     * @return RefinementVariableSlot that corresponds to this refinement
      */
-    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot declaredTypeSlot, Slot valueSlot);
+    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot delarationSlot, Slot valueSlot);
 
     /**
      * Create new ConstrantSlot and returns the reference to it if no

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -50,20 +50,20 @@ public interface SlotManager {
      *
      * @param location
      *            used to locate this refinement variable in code
-     * @param delarationSlot
+     * @param declarationSlot
      *            the VariableSlot for the lhs that gets refined
      * @param valueSlot
      *            the value that the given lhs VariableSlot is refined to. If it is
-     *            non-null, an equality constraint "delarationSlot == valueSlot" is
+     *            non-null, an equality constraint "declarationSlot == valueSlot" is
      *            created. Otherwise such constraint is created in
      *            {@link InferenceVisitor#maybeAddRefinementVariableConstraints}
-     *            Now we pass in non-null valueSlot only when lhs is declared type.
+     *            Currently we pass in non-null valueSlot only when lhs is a declared type.
      *            TODO: handle wildcards/type variables in the same way as declared
      *            type, so that this parameter is always non-null
      *
      * @return RefinementVariableSlot that corresponds to this refinement
      */
-    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot delarationSlot, Slot valueSlot);
+    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot declarationSlot, Slot valueSlot);
 
     /**
      * Create new ConstrantSlot and returns the reference to it if no

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -48,13 +48,17 @@ public interface SlotManager {
      * reference to existing RefinementVariableSlot on this location. Each
      * location uniquely identifies a RefinementVariableSlot
      *
+     * Create the related equality constraint if the refinement value is given.
+     *
      * @param location
      *            used to locate this variable in code.
-     * @param refined
+     * @param declaredTypeSlot
      *            a potential downward refinement of an existing VariableSlot
+     * @param valueSlot
+     *            the lhs value the existing VariableSlot is refined to
      * @return RefinementVariableSlot that corresponds to this location
      */
-    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot refined, Slot refineTo);
+    RefinementVariableSlot createRefinementVariableSlot(AnnotationLocation location, Slot declaredTypeSlot, Slot valueSlot);
 
     /**
      * Create new ConstrantSlot and returns the reference to it if no

--- a/src/checkers/inference/dataflow/InferenceTransfer.java
+++ b/src/checkers/inference/dataflow/InferenceTransfer.java
@@ -155,10 +155,13 @@ public class InferenceTransfer extends CFTransfer {
                 result = createTypeVarRefinementVars(assignmentNode.getTarget(), assignmentNode.getTree(),
                                                      store, (AnnotatedTypeVariable) atm);
             } else {
-                // Get the rhs value so the refinement variable slot being created can have the related
-                // equality constraint generated altogether
+                // Get the rhs value and pass it to slot manager to generate the equality constraint
+                // as "refinement variable == rhs value"
                 Tree valueTree = assignmentNode.getExpression().getTree();
                 AnnotatedTypeMirror valueType = typeFactory.getAnnotatedType(valueTree);
+
+                // If the rhs is type variable, the refinement value is the upper bound of it,
+                // because this is the most precise result we can infer
                 if (valueType.getKind() == TypeKind.TYPEVAR) {
                     valueType = InferenceUtil.findUpperBoundType((AnnotatedTypeVariable) valueType);
                 }
@@ -343,6 +346,8 @@ public class InferenceTransfer extends CFTransfer {
             // Create a refinement variable for each of the upper bound and the lower bound. But unlike the case
             // in the declared type refinement, here we pass null as the rhs value slot so no refinement constraint
             // is created. Refinement constraints for type variable will be created in InferenceVisitor
+            // TODO: we will finally pass non-null value slot to create refinement constraint here, rather than in
+            // InferenceVisitor, by resolving Issue: https://github.com/opprop/checker-framework-inference/issues/316
             upperBoundRefVar = slotManager.createRefinementVariableSlot(location, upperBoundSlot, null);
             lowerBoundRefVar = slotManager.createRefinementVariableSlot(location, lowerBoundSlot, null);
 

--- a/src/checkers/inference/dataflow/InferenceTransfer.java
+++ b/src/checkers/inference/dataflow/InferenceTransfer.java
@@ -160,8 +160,8 @@ public class InferenceTransfer extends CFTransfer {
                 Tree valueTree = assignmentNode.getExpression().getTree();
                 AnnotatedTypeMirror valueType = typeFactory.getAnnotatedType(valueTree);
 
-                // If the rhs is type variable, the refinement value is the upper bound of it,
-                // because this is the most precise result we can infer
+                // If the rhs is a type variable, the refinement value is the upper bound of it,
+                // because this is the most precise type we can use
                 if (valueType.getKind() == TypeKind.TYPEVAR) {
                     valueType = InferenceUtil.findUpperBoundType((AnnotatedTypeVariable) valueType);
                 }
@@ -365,6 +365,7 @@ public class InferenceTransfer extends CFTransfer {
 
         // This is a bit of a hack, but we want the LHS to now get the refinement annotation.
         // So change the value for LHS that is already in the store.
+        // TODO: We should finally remove this hack as what we've done for the declared type refinement
         getInferenceAnalysis().getNodeValues().put(lhs, result);
 
         store.updateForAssignment(lhs, result);

--- a/src/checkers/inference/dataflow/InferenceTransfer.java
+++ b/src/checkers/inference/dataflow/InferenceTransfer.java
@@ -155,6 +155,8 @@ public class InferenceTransfer extends CFTransfer {
                 result = createTypeVarRefinementVars(assignmentNode.getTarget(), assignmentNode.getTree(),
                                                      store, (AnnotatedTypeVariable) atm);
             } else {
+                // Get the rhs value so the refinement variable slot being created can have the related
+                // equality constraint generated altogether
                 Tree valueTree = assignmentNode.getExpression().getTree();
                 AnnotatedTypeMirror valueType = typeFactory.getAnnotatedType(valueTree);
                 if (valueType.getKind() == TypeKind.TYPEVAR) {
@@ -338,6 +340,9 @@ public class InferenceTransfer extends CFTransfer {
 
         } else {
             AnnotationLocation location = VariableAnnotator.treeToLocation(analysis.getTypeFactory(), assignmentTree);
+            // Create a refinement variable for each of the upper bound and the lower bound. But unlike the case
+            // in the declared type refinement, here we pass null as the rhs value slot so no refinement constraint
+            // is created. Refinement constraints for type variable will be created in InferenceVisitor
             upperBoundRefVar = slotManager.createRefinementVariableSlot(location, upperBoundSlot, null);
             lowerBoundRefVar = slotManager.createRefinementVariableSlot(location, lowerBoundSlot, null);
 


### PR DESCRIPTION
Remove the hack at https://github.com/opprop/checker-framework-inference/blob/939619aacfe930e0ff9f5dfc637f3556b0842f88/src/checkers/inference/dataflow/InferenceTransfer.java#L233

Each time when a new refinement variable is created, an equality constraint is created with it. Since in SSA form, an intermediate variable is assigned once and never changes.

Right now flow refinement is adapted for non-type-variable only. 