### PR TITLE
Use VarAnnot when getting the decl bound of a type

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -45,6 +45,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 
 import checkers.inference.dataflow.InferenceAnalysis;
@@ -575,6 +576,20 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     protected Set<? extends AnnotationMirror> getDefaultTypeDeclarationBounds() {
         return realTypeFactory.getQualifierHierarchy().getTopAnnotations();
+    }
+
+    /**
+     * Get the annotation from the class declaration.
+     * @param type a type
+     * @return the {@link VarAnnot} on the class bound, or the result from
+     * {@link org.checkerframework.framework.type.AnnotatedTypeFactory#getTypeDeclarationBounds}
+     * if the class is not handled by the {@link VariableAnnotator}.
+     */
+    @Override
+    public Set<AnnotationMirror> getTypeDeclarationBounds(TypeMirror type) {
+        AnnotationMirror vAnno =
+                variableAnnotator.getClassDeclVarAnnot(getProcessingEnv().getTypeUtils().asElement(type));
+        return vAnno == null ? Collections.singleton(vAnno) : super.getTypeDeclarationBounds(type);
     }
 }
 

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -589,7 +589,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     public Set<AnnotationMirror> getTypeDeclarationBounds(TypeMirror type) {
         AnnotationMirror vAnno =
                 variableAnnotator.getClassDeclVarAnnot(getProcessingEnv().getTypeUtils().asElement(type));
-        return vAnno == null ? Collections.singleton(vAnno) : super.getTypeDeclarationBounds(type);
+        return vAnno != null ? Collections.singleton(vAnno) : super.getTypeDeclarationBounds(type);
     }
 }
 

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -37,6 +37,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.ArrayTypeTree;
@@ -1630,6 +1631,20 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         }
 
         return declSlot;
+    }
+
+    /**
+     * Get the {@link VarAnnot} on the class declaration of the Element.
+     * @param ele an element
+     * @return the {@link VarAnnot} on the class declaration,
+     * or {@code null} if the class declaration of the Element is not handled by the
+     * {@link VariableAnnotator#getOrCreateDeclBound(AnnotatedDeclaredType)}.
+     */
+    public AnnotationMirror getClassDeclVarAnnot(Element ele) {
+        if (classDeclAnnos.get(ele) != null) {
+            return slotManager.getAnnotation(classDeclAnnos.get(ele));
+        }
+        return null;
     }
 
     private void addDeclarationConstraints(VariableSlot declSlot, VariableSlot instanceSlot) {


### PR DESCRIPTION
Return `VarAnnot` generated by the `VariableAnnotator` when calling `getTypeDeclarationBounds`.