### PR TITLE
Set location for existential variable

### DIFF
--- a/src/checkers/inference/model/ExistentialVariableSlot.java
+++ b/src/checkers/inference/model/ExistentialVariableSlot.java
@@ -72,6 +72,7 @@ public class ExistentialVariableSlot extends VariableSlot {
                                              + "potentialSlot=" + potentialSlot);
         }
 
+        this.setLocation(potentialSlot.getLocation());
         this.potentialSlot = potentialSlot;
         this.alternativeSlot = alternativeSlot;
     }


### PR DESCRIPTION
In debug mode, the AST path of an existential variable should be outputted the same as its potential variable.