### PR TITLE
Type declaration bounds in inference

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -574,15 +574,6 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Get the real top annotation from {@link #realTypeFactory}.
-     * @return the real top annotation.
-     */
-    @Override
-    protected Set<? extends AnnotationMirror> getDefaultTypeDeclarationBounds() {
-        return qualHierarchy.getTopAnnotations();
-    }
-
-    /**
      * Get the annotation from the class declaration.
      * @param type a type
      * @return the set of {@link VarAnnot} on the class bound. Unlike type checking,

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -576,16 +576,12 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /**
      * Get the annotation from the class declaration.
      * @param type a type
-     * @return the set of {@link VarAnnot} on the class bound. Unlike type checking,
-     * the returned set is always singleton in inference.
-     * {@link org.checkerframework.framework.type.AnnotatedTypeFactory#getTypeDeclarationBounds}
-     * if the class is not handled by the {@link VariableAnnotator}.
+     * @return the singleton set with the {@link VarAnnot} on the class bound
      */
     @Override
     public Set<AnnotationMirror> getTypeDeclarationBounds(TypeMirror type) {
         final TypeElement elt = (TypeElement) getProcessingEnv().getTypeUtils().asElement(type);
-        AnnotationMirror vAnno =
-                variableAnnotator.getClassDeclVarAnnot(elt);
+        AnnotationMirror vAnno = variableAnnotator.getClassDeclVarAnnot(elt);
         if (vAnno != null) {
             return Collections.singleton(vAnno);
         }

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -1,5 +1,7 @@
 package checkers.inference;
 
+import checkers.inference.model.ConstantSlot;
+import checkers.inference.model.Slot;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFAnalysis;
@@ -21,6 +23,7 @@ import org.checkerframework.framework.type.typeannotator.ListTypeAnnotator;
 import org.checkerframework.framework.type.typeannotator.TypeAnnotator;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
 import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
@@ -43,8 +46,10 @@ import java.util.logging.Logger;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 
 import checkers.inference.dataflow.InferenceAnalysis;
@@ -574,7 +579,28 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     @Override
     protected Set<? extends AnnotationMirror> getDefaultTypeDeclarationBounds() {
-        return realTypeFactory.getQualifierHierarchy().getTopAnnotations();
+        return qualHierarchy.getTopAnnotations();
+    }
+
+    /**
+     * Get the annotation from the class declaration.
+     * @param type a type
+     * @return the set of {@link VarAnnot} on the class bound. Unlike type checking,
+     * the returned set is always singleton in inference.
+     * {@link org.checkerframework.framework.type.AnnotatedTypeFactory#getTypeDeclarationBounds}
+     * if the class is not handled by the {@link VariableAnnotator}.
+     */
+    @Override
+    public Set<AnnotationMirror> getTypeDeclarationBounds(TypeMirror type) {
+        final TypeElement elt = (TypeElement) getProcessingEnv().getTypeUtils().asElement(type);
+        AnnotationMirror vAnno =
+                variableAnnotator.getClassDeclVarAnnot(elt);
+        if (vAnno != null) {
+            return Collections.singleton(vAnno);
+        }
+
+        // If the declaration bound of the underlying type is not cached, use default
+        return (Set<AnnotationMirror>) getDefaultTypeDeclarationBounds();
     }
 }
 

--- a/src/checkers/inference/InferenceQualifierHierarchy.java
+++ b/src/checkers/inference/InferenceQualifierHierarchy.java
@@ -1,6 +1,10 @@
 package checkers.inference;
 
-import checkers.inference.model.*;
+import checkers.inference.model.ConstantSlot;
+import checkers.inference.model.ConstraintManager;
+import checkers.inference.model.LubVariableSlot;
+import checkers.inference.model.Slot;
+import checkers.inference.model.VariableSlot;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotationMirrorSet;

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1619,8 +1619,6 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         if (declSlot == null) {
             Tree decl = inferenceTypeFactory.declarationFromElement(classDecl);
             if (decl != null) {
-                // Since each class decl should have a slot,
-                // do not use existential slot here.
                 declSlot = createVariable(decl);
                 classDeclAnnos.put(classDecl, declSlot);
 
@@ -1640,8 +1638,9 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * {@link VariableAnnotator#getOrCreateDeclBound(AnnotatedDeclaredType)}.
      */
     public AnnotationMirror getClassDeclVarAnnot(TypeElement ele) {
-        if (classDeclAnnos.get(ele) != null) {
-            return slotManager.getAnnotation(classDeclAnnos.get(ele));
+        final VariableSlot slot = classDeclAnnos.get(ele);
+        if (slot != null) {
+            return slotManager.getAnnotation(slot);
         }
         return null;
     }

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1612,7 +1612,6 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * If it does not already exist, this method creates the annotation and stores it in classDeclAnnos.
      */
     private VariableSlot getOrCreateDeclBound(AnnotatedDeclaredType type) {
-
         TypeElement classDecl = (TypeElement) type.getUnderlyingType().asElement();
 
         VariableSlot topConstant = getTopConstant();
@@ -1620,9 +1619,10 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         if (declSlot == null) {
             Tree decl = inferenceTypeFactory.declarationFromElement(classDecl);
             if (decl != null) {
-                VariableSlot potentialDeclSlot = createVariable(decl);
-                declSlot = getOrCreateExistentialVariable(potentialDeclSlot, topConstant);
-                classDeclAnnos.put(classDecl, potentialDeclSlot);
+                // Since each class decl should have a slot,
+                // do not use existential slot here.
+                declSlot = createVariable(decl);
+                classDeclAnnos.put(classDecl, declSlot);
 
             } else {
                 declSlot = topConstant;
@@ -1631,6 +1631,21 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
         return declSlot;
     }
+
+    /**
+     * Get the {@link VarAnnot} on the class declaration of the Element.
+     * @param ele an element
+     * @return the {@link VarAnnot} on the class declaration,
+     * or {@code null} if the class declaration of the Element is not handled by the
+     * {@link VariableAnnotator#getOrCreateDeclBound(AnnotatedDeclaredType)}.
+     */
+    public AnnotationMirror getClassDeclVarAnnot(TypeElement ele) {
+        if (classDeclAnnos.get(ele) != null) {
+            return slotManager.getAnnotation(classDeclAnnos.get(ele));
+        }
+        return null;
+    }
+
 
     private void addDeclarationConstraints(VariableSlot declSlot, VariableSlot instanceSlot) {
         constraintManager.addSubtypeConstraint(instanceSlot, declSlot);

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1631,10 +1631,10 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
     }
 
     /**
-     * Get the {@link VarAnnot} on the class declaration of the Element.
-     * @param ele an element
+     * Get the {@link VarAnnot} on the class declaration of the TypeElement.
+     * @param ele a type element
      * @return the {@link VarAnnot} on the class declaration,
-     * or {@code null} if the class declaration of the Element is not handled by the
+     * or {@code null} if the class declaration of the TypeElement is not handled by the
      * {@link VariableAnnotator#getOrCreateDeclBound(AnnotatedDeclaredType)}.
      */
     public AnnotationMirror getClassDeclVarAnnot(TypeElement ele) {


### PR DESCRIPTION
1. returns expected `@VarAnnot(?)` for `InferenceAnnotatedTypeFactory.getTypeDeclarationBounds`.
2. type declaration bound should be a normal source variable slot, instead of existential slot.

3. incorporate part of https://github.com/opprop/checker-framework-inference/pull/294, such that not to create existential slots for class bounds, i.e. type declaration bounds are always explicit in inference.