### PR TITLE
Record the TypeKind of arithmetic operation in ArithmeticVariableSlot

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -422,6 +422,12 @@ public class DefaultSlotManager implements SlotManager {
     }
 
 
+    /**
+     *  Determine the type kind of an arithmetic operation, based on Binary Numeric Promotion in JLS 5.6.2.
+     * @param lhsAtm atm of left operand
+     * @param rhsAtm atm of right operand
+     * @return type kind of the arithmetic operation
+     */
     private TypeKind getArithmeticResultKind(AnnotatedTypeMirror lhsAtm, AnnotatedTypeMirror rhsAtm) {
         TypeMirror lhsType = lhsAtm.getUnderlyingType();
         TypeMirror rhsType = rhsAtm.getUnderlyingType();

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -148,6 +148,8 @@ public interface SlotManager {
      * ArithmeticVariableSlot.
      *
      * @param location an AnnotationLocation used to locate this variable in code
+     * @param lhsAtm atm of the left operand
+     * @param rhsAtm atm of the right operand
      * @return the ArithmeticVariableSlot for the given location
      */
     ArithmeticVariableSlot createArithmeticVariableSlot(

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -150,7 +150,8 @@ public interface SlotManager {
      * @param location an AnnotationLocation used to locate this variable in code
      * @return the ArithmeticVariableSlot for the given location
      */
-    ArithmeticVariableSlot createArithmeticVariableSlot(AnnotationLocation location);
+    ArithmeticVariableSlot createArithmeticVariableSlot(
+            AnnotationLocation location, AnnotatedTypeMirror lhsAtm, AnnotatedTypeMirror rhsAtm);
 
     /**
      * Retrieves the ArithmeticVariableSlot created for the given location if it has been previously

--- a/src/checkers/inference/model/ArithmeticVariableSlot.java
+++ b/src/checkers/inference/model/ArithmeticVariableSlot.java
@@ -1,13 +1,23 @@
 package checkers.inference.model;
 
+import javax.lang.model.type.TypeKind;
+
 /**
  * ArithmeticVariableSlot represent the result of an arithmetic operation between two other
  * {@link Slot}s. Note that this slot is serialized identically to a {@link Slot}.
  */
 public class ArithmeticVariableSlot extends VariableSlot {
+    /**
+     * The value kind of the arithmetic operation, which indicates the value range.
+     * The result depends on the wider operand. i.e.
+     * If both sides are narrower than int => int
+     * If one sides is long => long
+     */
+    private TypeKind valueTypeKind;
 
-    public ArithmeticVariableSlot(int id, AnnotationLocation location) {
+    public ArithmeticVariableSlot(int id, AnnotationLocation location, TypeKind valueTypeKind) {
         super(id, location);
+        this.valueTypeKind = valueTypeKind;
     }
 
     @Override
@@ -28,5 +38,9 @@ public class ArithmeticVariableSlot extends VariableSlot {
     @Override
     public boolean isInsertable() {
         return false;
+    }
+
+    public TypeKind getValueTypeKind() {
+        return valueTypeKind;
     }
 }

--- a/src/checkers/inference/model/ArithmeticVariableSlot.java
+++ b/src/checkers/inference/model/ArithmeticVariableSlot.java
@@ -9,12 +9,17 @@ import javax.lang.model.type.TypeKind;
 public class ArithmeticVariableSlot extends VariableSlot {
     /**
      * The value kind of the arithmetic operation, which indicates the value range.
-     * The result depends on the wider operand. i.e.
-     * If both sides are narrower than int => int
-     * If one sides is long => long
+     * (i) If one operand is long => long
+     * (ii) otherwise => int
      */
     private final TypeKind valueTypeKind;
 
+    /**
+     * Constructor
+     * @param id slot id
+     * @param location location of the slot
+     * @param valueTypeKind the type kind of the arithmetic operation
+     */
     public ArithmeticVariableSlot(int id, AnnotationLocation location, TypeKind valueTypeKind) {
         super(id, location);
         this.valueTypeKind = valueTypeKind;

--- a/src/checkers/inference/model/ArithmeticVariableSlot.java
+++ b/src/checkers/inference/model/ArithmeticVariableSlot.java
@@ -13,7 +13,7 @@ public class ArithmeticVariableSlot extends VariableSlot {
      * If both sides are narrower than int => int
      * If one sides is long => long
      */
-    private TypeKind valueTypeKind;
+    private final TypeKind valueTypeKind;
 
     public ArithmeticVariableSlot(int id, AnnotationLocation location, TypeKind valueTypeKind) {
         super(id, location);


### PR DESCRIPTION
Record the TypeKind of the arithmetic operation result, which indicates the value range.
The result depends on the wider operand. i.e.

- If both sides are int or narrower than int => arithmetic slot's type kind int

- If one side is long => arithmetic slot's type kind is long