### PR TITLE
Duplicate element ATM before get/put

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1205,10 +1205,6 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
             final TypeParameterElement typeParamElement = (TypeParameterElement) typeVar.getUnderlyingType().asElement();
             final TypeParameterTree typeParameterTree   = (TypeParameterTree) tree;
 
-            if (!elementToAtm.containsKey(typeParamElement)) {
-                storeElementType(typeParamElement, typeVar);
-            }
-
             // add lower bound annotation
             addPrimaryVariable(typeVar.getLowerBound(), tree);
 
@@ -1251,6 +1247,11 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
 
                 final AnnotatedTypeMirror upperBound = typeVar.getUpperBound();
                 upperBound.addAnnotation(slotManager.getAnnotation(extendsSlot));
+            }
+
+            if (!elementToAtm.containsKey(typeParamElement)) {
+                // cache the element ATM when it's fully annotated
+                storeElementType(typeParamElement, typeVar);
             }
 
         } else  {


### PR DESCRIPTION
`elementToAtm` is a HashMap that caches the ATMs of various elements, i.e. it stores the declared type of variables and type variables. Therefore, it's important to prevent the stored ATMs from side-effect by:

1. store into `elementToAtm` the copy of the atm that is to being cached
2. use the copy of the atm that are fetched from `elementToAtm`