### PR TITLE
changed access modifier of getOrCreateDeclBound() to protected

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1656,8 +1656,12 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
     /**
      * This method returns the annotation that may or may not be placed on the class declaration for type.
      * If it does not already exist, this method creates the annotation and stores it in classDeclAnnos.
+     *
+     * We can override this method and just return getTopConstant() when we don't want class declaration
+     * annotations (e.g., in the case of universe type system)
+     *
      */
-    private Slot getOrCreateDeclBound(AnnotatedDeclaredType type) {
+    protected Slot getOrCreateDeclBound(AnnotatedDeclaredType type) {
         TypeElement classElt = (TypeElement) type.getUnderlyingType().asElement();
 
         Slot topConstant = getTopConstant();

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1658,7 +1658,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * If it does not already exist, this method creates the annotation and stores it in classDeclAnnos.
      *
      * We can override this method and just return getTopConstant() when we don't want class declaration
-     * annotations (e.g., in the case of universe type system)
+     * annotations (e.g., in the case of universe type system) 
      *
      */
     protected Slot getOrCreateDeclBound(AnnotatedDeclaredType type) {

--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1657,8 +1657,8 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
      * This method returns the annotation that may or may not be placed on the class declaration for type.
      * If it does not already exist, this method creates the annotation and stores it in classDeclAnnos.
      *
-     * We can override this method and just return getTopConstant() when we don't want class declaration
-     * annotations (e.g., in the case of universe type system) 
+     * This method can be overridden if a type system wants to use a fixed annotation for class declarations. 
+     * For example, using the top annotation effectively disables declaration bound checks. 
      *
      */
     protected Slot getOrCreateDeclBound(AnnotatedDeclaredType type) {


### PR DESCRIPTION
`getOrCreateDeclBound()` can now be overridden and developers of a type system (e.g., universe type system) can exclude class declaration annotations. 