### PR TITLE
Fix crash when an interface contains an array literal

### DIFF
--- a/src/checkers/inference/VariableAnnotator.java
+++ b/src/checkers/inference/VariableAnnotator.java
@@ -1038,6 +1038,7 @@ public class VariableAnnotator extends AnnotatedTypeScanner<Void,Tree> {
         treeKinds.add(Kind.TYPE_ANNOTATION);
         treeKinds.add(Kind.METHOD);
         treeKinds.add(Kind.CLASS);
+        treeKinds.add(Kind.INTERFACE);
         Tree enclosure = TreePathUtil.enclosingOfKind(path, treeKinds);
         return enclosure.getKind() == Kind.ANNOTATION
             || enclosure.getKind() == Kind.ANNOTATION_TYPE

--- a/testdata/ostrusted-inferrable-test/ConstantArray.java
+++ b/testdata/ostrusted-inferrable-test/ConstantArray.java
@@ -1,4 +1,4 @@
-// The test case in https://github.com/opprop/checker-framework-inference/pull/366
+// The test for https://github.com/opprop/checker-framework-inference/pull/366
 
 public interface ConstantArray {
     String[] ACCESS_NAMES = {

--- a/testdata/ostrusted-inferrable-test/ConstantArray.java
+++ b/testdata/ostrusted-inferrable-test/ConstantArray.java
@@ -1,6 +1,6 @@
 // The test case in https://github.com/opprop/checker-framework-inference/pull/366
 
-public interface Constants {
+public interface ConstantArray {
     String[] ACCESS_NAMES = {
         "public", "private", "protected", "static", "final", "synchronized",
         "volatile", "transient", "native", "interface", "abstract", "strictfp",

--- a/testdata/ostrusted-inferrable-test/ConstantArray.java
+++ b/testdata/ostrusted-inferrable-test/ConstantArray.java
@@ -7,4 +7,3 @@ public interface ConstantArray {
         "synthetic", "annotation", "enum"
     };
 }
-

--- a/testdata/ostrusted-inferrable-test/ConstantArray.java
+++ b/testdata/ostrusted-inferrable-test/ConstantArray.java
@@ -1,4 +1,4 @@
-// The test for https://github.com/opprop/checker-framework-inference/pull/366
+// Test for https://github.com/opprop/checker-framework-inference/pull/366
 
 public interface ConstantArray {
     String[] ACCESS_NAMES = {

--- a/testdata/ostrusted-inferrable-test/ConstantArray.java
+++ b/testdata/ostrusted-inferrable-test/ConstantArray.java
@@ -5,7 +5,6 @@ public interface ConstantArray {
         "public", "private", "protected", "static", "final", "synchronized",
         "volatile", "transient", "native", "interface", "abstract", "strictfp",
         "synthetic", "annotation", "enum"
-
     };
 }
 

--- a/testdata/ostrusted-inferrable-test/ConstantArray.java
+++ b/testdata/ostrusted-inferrable-test/ConstantArray.java
@@ -1,3 +1,5 @@
+// The test case in https://github.com/opprop/checker-framework-inference/pull/366
+
 public interface Constants {
     String[] ACCESS_NAMES = {
         "public", "private", "protected", "static", "final", "synchronized",

--- a/testdata/ostrusted-inferrable-test/Constants.java
+++ b/testdata/ostrusted-inferrable-test/Constants.java
@@ -1,0 +1,9 @@
+public interface Constants {
+    String[] ACCESS_NAMES = {
+        "public", "private", "protected", "static", "final", "synchronized",
+        "volatile", "transient", "native", "interface", "abstract", "strictfp",
+        "synthetic", "annotation", "enum"
+
+    };
+}
+


### PR DESCRIPTION
Found a case that causes crash,
```
public interface Constants {
    String[] ACCESS_NAMES = {
        "public", "private", "protected", "static", "final", "synchronized",
        "volatile", "transient", "native", "interface", "abstract", "strictfp",
        "synthetic", "annotation", "enum"

    };
}
```

The reason is that in `VariableAnnotator.annotateArrayLiteral`, it firstly check if the array is an annotation element, by calling `enclosedByAnnotation`, which triggers NullPointerException when the array is declared in an interface. 