### PR TITLE
Update Z3SmtSoftConstraintEncoder

### DIFF
--- a/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
+++ b/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
@@ -17,6 +17,7 @@ import checkers.inference.model.PreferenceConstraint;
 import checkers.inference.model.SubtypeConstraint;
 import checkers.inference.solver.backend.z3smt.Z3SmtFormatTranslator;
 import checkers.inference.solver.frontend.Lattice;
+import org.checkerframework.javacutil.BugInCF;
 
 public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
         extends Z3SmtAbstractConstraintEncoder<SlotEncodingT, SlotSolutionT> {
@@ -38,35 +39,15 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
 
     protected abstract void encodeSoftSubtypeConstraint(SubtypeConstraint constraint);
 
-    protected abstract void encodeSoftComparableConstraint(ComparableConstraint constraint);
-
-    protected abstract void encodeSoftArithmeticConstraint(ArithmeticConstraint constraint);
-
     protected abstract void encodeSoftEqualityConstraint(EqualityConstraint constraint);
 
     protected abstract void encodeSoftInequalityConstraint(InequalityConstraint constraint);
-
-    protected abstract void encodeSoftImplicationConstraint(ImplicationConstraint constraint);
-
-    protected abstract void encodeSoftExistentialConstraint(ExistentialConstraint constraint);
-
-    protected abstract void encodeSoftCombineConstraint(CombineConstraint constraint);
-
-    protected abstract void encodeSoftPreferenceConstraint(PreferenceConstraint constraint);
 
     public String encodeAndGetSoftConstraints(Collection<Constraint> constraints) {
         for (Constraint constraint : constraints) {
             // Generate a soft constraint for subtype constraint
             if (constraint instanceof SubtypeConstraint) {
                 encodeSoftSubtypeConstraint((SubtypeConstraint) constraint);
-            }
-            // Generate soft constraint for comparable constraint
-            else if (constraint instanceof ComparableConstraint) {
-                encodeSoftComparableConstraint((ComparableConstraint) constraint);
-            }
-            // Generate soft constraint for arithmetic constraint
-            else if (constraint instanceof ArithmeticConstraint) {
-                encodeSoftArithmeticConstraint((ArithmeticConstraint) constraint);
             }
             // Generate soft constraint for equality constraint
             else if (constraint instanceof EqualityConstraint) {
@@ -76,22 +57,7 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
             else if (constraint instanceof InequalityConstraint) {
                 encodeSoftInequalityConstraint((InequalityConstraint) constraint);
             }
-            // Generate soft constraint for implication constraint
-            else if (constraint instanceof ImplicationConstraint) {
-                encodeSoftImplicationConstraint((ImplicationConstraint) constraint);
-            }
-            // Generate soft constraint for existential constraint
-            else if (constraint instanceof ExistentialConstraint) {
-                encodeSoftExistentialConstraint((ExistentialConstraint) constraint);
-            }
-            // Generate soft constraint for combine constraint
-            else if (constraint instanceof CombineConstraint) {
-                encodeSoftCombineConstraint((CombineConstraint) constraint);
-            }
-            // Generate soft constraint for preference constraint
-            else if (constraint instanceof PreferenceConstraint) {
-                encodeSoftPreferenceConstraint((PreferenceConstraint) constraint);
-            }
+            throw new BugInCF("Soft constraint for " + constraint.getClass().getName() + " is not supported");
         }
         return softConstraints.toString();
     }

--- a/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
+++ b/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
@@ -43,15 +43,12 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
     protected abstract void encodeSoftInequalityConstraint(InequalityConstraint constraint);
 
     /**
-     * Encode a set of constraints as soft constraints. Note that the field of StringBuilder
-     * {@code softConstraints} is first cleared each time this method is called.
+     * Encode a set of constraints as soft constraints.
+     *
      * @param constraints constraints to be encoded as soft constraints
      * @return a string representation of the encoding of soft constraints
      */
     public String encodeAndGetSoftConstraints(Collection<Constraint> constraints) {
-        // clear previous encoding result before encoding
-        softConstraints.setLength(0);
-
         for (Constraint constraint : constraints) {
             if (constraint instanceof SubtypeConstraint) {
                 encodeSoftSubtypeConstraint((SubtypeConstraint) constraint);
@@ -66,6 +63,9 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
                 throw new BugInCF("Soft constraint for " + constraint.getClass().getName() + " is not supported");
             }
         }
-        return softConstraints.toString();
+        String res = softConstraints.toString();
+        // clear field for next usage
+        softConstraints.setLength(0);
+        return res;
     }
 }

--- a/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
+++ b/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
@@ -34,44 +34,63 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
     protected void addSoftConstraint(Expr serializedConstraint, int weight) {
         softConstraints.append("(assert-soft " + serializedConstraint + " :weight " + weight + ")\n");
     }
-    
+
+
+    protected abstract void encodeSoftSubtypeConstraint(SubtypeConstraint constraint);
+
+    protected abstract void encodeSoftComparableConstraint(ComparableConstraint constraint);
+
+    protected abstract void encodeSoftArithmeticConstraint(ArithmeticConstraint constraint);
+
+    protected abstract void encodeSoftEqualityConstraint(EqualityConstraint constraint);
+
+    protected abstract void encodeSoftInequalityConstraint(InequalityConstraint constraint);
+
+    protected abstract void encodeSoftImplicationConstraint(ImplicationConstraint constraint);
+
+    protected abstract void encodeSoftExistentialConstraint(ExistentialConstraint constraint);
+
+    protected abstract void encodeSoftCombineConstraint(CombineConstraint constraint);
+
+    protected abstract void encodeSoftPreferenceConstraint(PreferenceConstraint constraint);
+
     public String encodeAndGetSoftConstraints(Collection<Constraint> constraints) {
         for (Constraint constraint : constraints) {
             // Generate a soft constraint for subtype constraint
             if (constraint instanceof SubtypeConstraint) {
-                encodeSubtypeConstraint((SubtypeConstraint) constraint);
+                encodeSoftSubtypeConstraint((SubtypeConstraint) constraint);
             }
-            // Generate soft constraint for comparison constraint
-            if (constraint instanceof ComparableConstraint) {
-                encodeComparableConstraint((ComparableConstraint) constraint);
+            // Generate soft constraint for comparable constraint
+            else if (constraint instanceof ComparableConstraint) {
+                encodeSoftComparableConstraint((ComparableConstraint) constraint);
             }
             // Generate soft constraint for arithmetic constraint
-            if (constraint instanceof ArithmeticConstraint) {
-                encodeArithmeticConstraint((ArithmeticConstraint) constraint);
+            else if (constraint instanceof ArithmeticConstraint) {
+                encodeSoftArithmeticConstraint((ArithmeticConstraint) constraint);
             }
             // Generate soft constraint for equality constraint
-            if (constraint instanceof EqualityConstraint) {
-                encodeEqualityConstraint((EqualityConstraint) constraint);
+            else if (constraint instanceof EqualityConstraint) {
+                encodeSoftEqualityConstraint((EqualityConstraint) constraint);
             }
             // Generate soft constraint for inequality constraint
-            if (constraint instanceof InequalityConstraint) {
-                encodeInequalityConstraint((InequalityConstraint) constraint);
+            else if (constraint instanceof InequalityConstraint) {
+                encodeSoftInequalityConstraint((InequalityConstraint) constraint);
             }
             // Generate soft constraint for implication constraint
-            if (constraint instanceof ImplicationConstraint) {
-                encodeImplicationConstraint((ImplicationConstraint) constraint);
+            else if (constraint instanceof ImplicationConstraint) {
+                encodeSoftImplicationConstraint((ImplicationConstraint) constraint);
             }
             // Generate soft constraint for existential constraint
-            if (constraint instanceof ExistentialConstraint) {
-                encodeExistentialConstraint((ExistentialConstraint) constraint);
+            else if (constraint instanceof ExistentialConstraint) {
+                encodeSoftExistentialConstraint((ExistentialConstraint) constraint);
             }
             // Generate soft constraint for combine constraint
-            if (constraint instanceof CombineConstraint) {
-                encodeCombineConstraint((CombineConstraint) constraint);
+            else if (constraint instanceof CombineConstraint) {
+                encodeSoftCombineConstraint((CombineConstraint) constraint);
             }
             // Generate soft constraint for preference constraint
-            if (constraint instanceof PreferenceConstraint) {
-                encodePreferenceConstraint((PreferenceConstraint) constraint);
+            else if (constraint instanceof PreferenceConstraint) {
+                encodeSoftPreferenceConstraint((PreferenceConstraint) constraint);
             }
         }
         return softConstraints.toString();

--- a/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
+++ b/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
@@ -42,21 +42,29 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
 
     protected abstract void encodeSoftInequalityConstraint(InequalityConstraint constraint);
 
+    /**
+     * Encode a set of constraints as soft constraints. Note that the field of StringBuilder
+     * {@code softConstraints} is first cleared each time this method is called.
+     * @param constraints constraints to be encoded as soft constraints
+     * @return a string representation of the encoding of soft constraints
+     */
     public String encodeAndGetSoftConstraints(Collection<Constraint> constraints) {
+        // clear previous encoding result before encoding
+        softConstraints.setLength(0);
+
         for (Constraint constraint : constraints) {
-            // Generate a soft constraint for subtype constraint
             if (constraint instanceof SubtypeConstraint) {
                 encodeSoftSubtypeConstraint((SubtypeConstraint) constraint);
-            }
-            // Generate soft constraint for equality constraint
-            else if (constraint instanceof EqualityConstraint) {
+
+            } else if (constraint instanceof EqualityConstraint) {
                 encodeSoftEqualityConstraint((EqualityConstraint) constraint);
-            }
-            // Generate soft constraint for inequality constraint
-            else if (constraint instanceof InequalityConstraint) {
+
+            } else if (constraint instanceof InequalityConstraint) {
                 encodeSoftInequalityConstraint((InequalityConstraint) constraint);
+
+            } else {
+                throw new BugInCF("Soft constraint for " + constraint.getClass().getName() + " is not supported");
             }
-            throw new BugInCF("Soft constraint for " + constraint.getClass().getName() + " is not supported");
         }
         return softConstraints.toString();
     }

--- a/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
+++ b/src/checkers/inference/solver/backend/z3smt/encoder/Z3SmtSoftConstraintEncoder.java
@@ -36,7 +36,6 @@ public abstract class Z3SmtSoftConstraintEncoder<SlotEncodingT, SlotSolutionT>
         softConstraints.append("(assert-soft " + serializedConstraint + " :weight " + weight + ")\n");
     }
 
-
     protected abstract void encodeSoftSubtypeConstraint(SubtypeConstraint constraint);
 
     protected abstract void encodeSoftEqualityConstraint(EqualityConstraint constraint);


### PR DESCRIPTION
Add abstract methods for Z3Smt solver only.  This is only used in value-inference.

Co-authored-by: Jenny Xiang <j.tt.xiang@gmail.com>