### PR TITLE
Avoid reading type info from trees that are not being processed

### DIFF
--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -430,7 +430,13 @@ public class DefaultSlotManager implements SlotManager {
         if (tree != null && realAnnotation == null) {
             // If its default type can't be found in the cache, we can
             // fallback to the simplest method.
-            realAnnotation = realTypeFactory.getAnnotatedType(tree).getAnnotationInHierarchy(this.realTop);
+            if (TreeUtils.isTypeTree(tree)) {
+                realAnnotation = realTypeFactory.getAnnotatedTypeFromTypeTree(tree)
+                        .getAnnotationInHierarchy(this.realTop);
+            } else {
+                realAnnotation = realTypeFactory.getAnnotatedType(tree)
+                        .getAnnotationInHierarchy(this.realTop);
+            }
         }
         return realAnnotation;
     }

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -143,14 +143,12 @@ public class DefaultSlotManager implements SlotManager {
 
     private final Set<Class<? extends Annotation>> realQualifiers;
     private final ProcessingEnvironment processingEnvironment;
-    private final InferenceChecker inferenceChecker;
 
-    public DefaultSlotManager( final InferenceChecker inferenceChecker,
+    public DefaultSlotManager( final ProcessingEnvironment processingEnvironment,
                                final AnnotationMirror realTop,
                                final Set<Class<? extends Annotation>> realQualifiers,
                                boolean storeConstants) {
-        this.inferenceChecker = inferenceChecker;
-        this.processingEnvironment = inferenceChecker.getProcessingEnvironment();
+        this.processingEnvironment = processingEnvironment;
         this.realTop = realTop;
         // sort the qualifiers so that they are always assigned the same varId
         this.realQualifiers = sortAnnotationClasses(realQualifiers);
@@ -407,7 +405,7 @@ public class DefaultSlotManager implements SlotManager {
 
         if (!defaultAnnotationsCache.containsKey(tree)) {
             // If cache misses, we check if the top level class has changed.
-            ClassTree topLevelClass = inferenceChecker.getCurrentTopLevelClass();
+            ClassTree topLevelClass = InferenceMain.getInstance().getVisitor().getCurrentTopLevelClass();
 
             if (!defaultAnnotationsCache.containsKey(topLevelClass)) {
                 // If the top level has changed, we refresh our cache with the new scope.

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -13,6 +13,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypeKindUtils;
 import org.checkerframework.javacutil.TypesUtils;
 

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -430,6 +430,10 @@ public class DefaultSlotManager implements SlotManager {
         if (tree != null && realAnnotation == null) {
             // If its default type can't be found in the cache, we can
             // fallback to the simplest method.
+            // TODO: If the tree is not under the current top-level tree
+            //  that's being processed, the type factory may crash due
+            //  to lack of information. We may want to investigate if
+            //  this issue ever happens.
             if (TreeUtils.isTypeTree(tree)) {
                 realAnnotation = realTypeFactory.getAnnotatedTypeFromTypeTree(tree)
                         .getAnnotationInHierarchy(this.realTop);

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -143,12 +143,14 @@ public class DefaultSlotManager implements SlotManager {
 
     private final Set<Class<? extends Annotation>> realQualifiers;
     private final ProcessingEnvironment processingEnvironment;
+    private final InferenceChecker inferenceChecker;
 
-    public DefaultSlotManager( final ProcessingEnvironment processingEnvironment,
+    public DefaultSlotManager( final InferenceChecker inferenceChecker,
                                final AnnotationMirror realTop,
                                final Set<Class<? extends Annotation>> realQualifiers,
                                boolean storeConstants) {
-        this.processingEnvironment = processingEnvironment;
+        this.inferenceChecker = inferenceChecker;
+        this.processingEnvironment = inferenceChecker.getProcessingEnvironment();
         this.realTop = realTop;
         // sort the qualifiers so that they are always assigned the same varId
         this.realQualifiers = sortAnnotationClasses(realQualifiers);
@@ -405,7 +407,7 @@ public class DefaultSlotManager implements SlotManager {
 
         if (!defaultAnnotationsCache.containsKey(tree)) {
             // If cache misses, we check if the top level class has changed.
-            ClassTree topLevelClass = InferenceMain.getInstance().getVisitor().getCurrentTopLevelClass();
+            ClassTree topLevelClass = inferenceChecker.getCurrentTopLevelClass();
 
             if (!defaultAnnotationsCache.containsKey(topLevelClass)) {
                 // If the top level has changed, we refresh our cache with the new scope.

--- a/src/checkers/inference/DefaultSlotManager.java
+++ b/src/checkers/inference/DefaultSlotManager.java
@@ -10,7 +10,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
-import org.checkerframework.javacutil.*;
+import org.checkerframework.javacutil.AnnotationBuilder;
+import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.TypeKindUtils;
+import org.checkerframework.javacutil.TypesUtils;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -530,7 +530,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
 
             if (declaration != null) {
-                ClassTree currentTopClass = inferenceChecker.getCurrentTopLevelClass();
+                ClassTree topLevelClass = inferenceChecker.getCurrentTopLevelClass();
                 TreePath path = getPath(declaration);
 
                 // We need to check whether the declaration is within the current
@@ -539,7 +539,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 // processed or should be processed in the future (when compiler
                 // sends out an event).
                 while (path != null) {
-                    if (path.getLeaf() == currentTopClass) {
+                    if (path.getLeaf() == topLevelClass) {
                         treeAnnotator.visit(declaration, type);
                     }
                     path = path.getParentPath();

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -530,20 +530,7 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
 
             if (declaration != null) {
-                ClassTree topLevelClass = inferenceChecker.getCurrentTopLevelClass();
-                TreePath path = getPath(declaration);
-
-                // We need to check whether the declaration is within the current
-                // top class that is being processed. If yes, we should annotate
-                // the declaration right now. Otherwise, the declaration is already
-                // processed or should be processed in the future (when compiler
-                // sends out an event).
-                while (path != null) {
-                    if (path.getLeaf() == topLevelClass) {
-                        treeAnnotator.visit(declaration, type);
-                    }
-                    path = path.getParentPath();
-                }
+                treeAnnotator.visit(declaration, type);
             } else {
                 bytecodeTypeAnnotator.annotate(element, type);
             }

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -27,7 +27,11 @@ import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
-import org.checkerframework.javacutil.*;
+import org.checkerframework.javacutil.AnnotationBuilder;
+import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.Pair;
+import org.checkerframework.javacutil.TreeUtils;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;

--- a/src/checkers/inference/InferenceChecker.java
+++ b/src/checkers/inference/InferenceChecker.java
@@ -39,6 +39,15 @@ public class InferenceChecker extends BaseTypeChecker {
     }
 
     @Override
+    public Properties getMessagesProperties() {
+        // Add the messages.properties file defined in the same location as
+        // InferenceChecker
+        Properties messages = super.getMessagesProperties();
+        messages.putAll(getProperties(this.getClass(), MSGS_FILE, true));
+        return messages;
+    }
+
+    @Override
     public void typeProcess(TypeElement element, TreePath treePath) {
         // As the entry point for type processing, each time we will receive
         // one fully-analyzed class directly under a compilation unit tree.

--- a/src/checkers/inference/InferenceChecker.java
+++ b/src/checkers/inference/InferenceChecker.java
@@ -39,15 +39,6 @@ public class InferenceChecker extends BaseTypeChecker {
     }
 
     @Override
-    public Properties getMessagesProperties() {
-        // Add the messages.properties file defined in the same location as
-        // InferenceChecker
-        Properties messages = super.getMessagesProperties();
-        messages.putAll(getProperties(this.getClass(), MSGS_FILE, true));
-        return messages;
-    }
-
-    @Override
     public void typeProcess(TypeElement element, TreePath treePath) {
         // As the entry point for type processing, each time we will receive
         // one fully-analyzed class directly under a compilation unit tree.

--- a/src/checkers/inference/InferenceChecker.java
+++ b/src/checkers/inference/InferenceChecker.java
@@ -1,24 +1,9 @@
 package checkers.inference;
 
-import java.util.Properties;
-
-import com.sun.source.tree.ClassTree;
-import com.sun.source.util.TreePath;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 
-import javax.lang.model.element.TypeElement;
-
 public class InferenceChecker extends BaseTypeChecker {
-
-    /**
-     * This field stores current top level class tree that's being type processed.
-     *
-     * Note that trees that are not within this tree may be missing some information
-     * (in the JCTree implementation), and this is because they are either not fully
-     * initialized or being garbage-recycled.
-     */
-    private ClassTree currentTopLevelClass;
 
     @Override
     public void initChecker() {
@@ -27,7 +12,6 @@ public class InferenceChecker extends BaseTypeChecker {
         super.initChecker();
         // Overrides visitor created by initChecker
         this.visitor = InferenceMain.getInstance().getVisitor();
-        this.currentTopLevelClass = null;
     }
 
     /**
@@ -36,27 +20,5 @@ public class InferenceChecker extends BaseTypeChecker {
     @Override
     protected BaseTypeVisitor<?> createSourceVisitor() {
         return null;
-    }
-
-    @Override
-    public Properties getMessagesProperties() {
-        // Add the messages.properties file defined in the same location as
-        // InferenceChecker
-        Properties messages = super.getMessagesProperties();
-        messages.putAll(getProperties(this.getClass(), MSGS_FILE, true));
-        return messages;
-    }
-
-    @Override
-    public void typeProcess(TypeElement element, TreePath treePath) {
-        // As the entry point for type processing, each time we will receive
-        // one fully-analyzed class directly under a compilation unit tree.
-        // Please check the documentation in AbstractTypeProcessor for more details.
-        this.currentTopLevelClass = (ClassTree) treePath.getLeaf();
-        super.typeProcess(element, treePath);
-    }
-
-    public ClassTree getCurrentTopLevelClass() {
-        return currentTopLevelClass;
     }
 }

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -363,7 +363,7 @@ public class InferenceMain {
             }
 
             slotManager = new DefaultSlotManager(
-                    inferenceChecker,
+                    inferenceChecker.getProcessingEnvironment(),
                     tops.iterator().next(),
                     realTypeFactory.getSupportedTypeQualifiers(),
                     true

--- a/src/checkers/inference/InferenceMain.java
+++ b/src/checkers/inference/InferenceMain.java
@@ -363,7 +363,7 @@ public class InferenceMain {
             }
 
             slotManager = new DefaultSlotManager(
-                    inferenceChecker.getProcessingEnvironment(),
+                    inferenceChecker,
                     tops.iterator().next(),
                     realTypeFactory.getSupportedTypeQualifiers(),
                     true

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -1,5 +1,7 @@
 package checkers.inference;
 
+import com.sun.source.tree.ClassTree;
+import com.sun.source.util.TreePath;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
@@ -61,7 +63,7 @@ import org.plumelib.util.ArraysPlume;
  *  That is, the methods from BaseTypeVisiotr should be migrated here and InferenceVisitor
  *  should replace it in the Visitor hierarchy.
  */
-// TODO(Zhiping): new logics from BaseTypeVisiotr should be migrated here
+// TODO(Zhiping): new logics from BaseTypeVisitor should be migrated here
 public class InferenceVisitor<Checker extends InferenceChecker,
         Factory extends BaseAnnotatedTypeFactory>
         extends BaseTypeVisitor<Factory> {
@@ -88,6 +90,15 @@ public class InferenceVisitor<Checker extends InferenceChecker,
     @Override
     protected Factory createTypeFactory() {
         return (Factory)((BaseInferrableChecker)checker).getTypeFactory();
+    }
+
+    @Override
+    public void visit(TreePath path) {
+        if (infer) {
+            final SlotManager slotManager = InferenceMain.getInstance().getSlotManager();
+            slotManager.setTopLevelClass((ClassTree) path.getLeaf());
+        }
+        super.visit(path);
     }
 
     public void doesNotContain(AnnotatedTypeMirror ty, AnnotationMirror mod, String msgkey, Tree node) {

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -43,7 +43,6 @@ import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.VariableTree;
-import com.sun.source.tree.ClassTree;
 
 import org.plumelib.util.ArraysPlume;
 
@@ -89,10 +88,6 @@ public class InferenceVisitor<Checker extends InferenceChecker,
     @Override
     protected Factory createTypeFactory() {
         return (Factory)((BaseInferrableChecker)checker).getTypeFactory();
-    }
-
-    public ClassTree getCurrentTopLevelClass() {
-        return ((InferenceChecker) checker).getCurrentTopLevelClass();
     }
 
     public void doesNotContain(AnnotatedTypeMirror ty, AnnotationMirror mod, String msgkey, Tree node) {

--- a/src/checkers/inference/InferenceVisitor.java
+++ b/src/checkers/inference/InferenceVisitor.java
@@ -43,6 +43,7 @@ import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.tree.ClassTree;
 
 import org.plumelib.util.ArraysPlume;
 
@@ -88,6 +89,10 @@ public class InferenceVisitor<Checker extends InferenceChecker,
     @Override
     protected Factory createTypeFactory() {
         return (Factory)((BaseInferrableChecker)checker).getTypeFactory();
+    }
+
+    public ClassTree getCurrentTopLevelClass() {
+        return ((InferenceChecker) checker).getCurrentTopLevelClass();
     }
 
     public void doesNotContain(AnnotatedTypeMirror ty, AnnotationMirror mod, String msgkey, Tree node) {

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -219,12 +219,4 @@ public interface SlotManager {
     List<VariableSlot> getVariableSlots();
 
     List<ConstantSlot> getConstantSlots();
-
-    /**
-     * Informs this manager that we are working on a new file, so
-     * it can preprocess and cache useful information.
-     *
-     * @param compilationUnit the current compilation tree
-     */
-    void setRoot(CompilationUnitTree compilationUnit);
 }

--- a/src/checkers/inference/SlotManager.java
+++ b/src/checkers/inference/SlotManager.java
@@ -1,6 +1,7 @@
 package checkers.inference;
 
 import checkers.inference.model.LubVariableSlot;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
@@ -219,4 +220,15 @@ public interface SlotManager {
     List<VariableSlot> getVariableSlots();
 
     List<ConstantSlot> getConstantSlots();
+
+    /**
+     * This method informs slot manager of the current top level class tree that's being type processed.
+     * Slot manager can then preprocess this information by clearing caches, resolving slot default
+     * types, etc.
+     *
+     * Note that trees that are not within this tree may be missing some information
+     * (in the JCTree implementation), and this is because they are either not fully
+     * initialized or being garbage-recycled.
+     */
+    void setTopLevelClass(ClassTree classTree);
 }

--- a/src/checkers/inference/util/SlotDefaultTypeResolver.java
+++ b/src/checkers/inference/util/SlotDefaultTypeResolver.java
@@ -3,7 +3,6 @@ package checkers.inference.util;
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
@@ -38,11 +37,11 @@ import java.util.Map;
 public class SlotDefaultTypeResolver {
 
     public static Map<Tree, AnnotatedTypeMirror> resolve(
-            CompilationUnitTree root,
+            ClassTree classTree,
             BaseAnnotatedTypeFactory realTypeFactory
     ) {
         DefaultTypeFinder finder = new DefaultTypeFinder(realTypeFactory);
-        finder.scan(root, null);
+        finder.scan(classTree, null);
 
         return finder.defaultTypes;
     }
@@ -89,6 +88,9 @@ public class SlotDefaultTypeResolver {
 
         @Override
         public Void visitClass(ClassTree tree, Void unused) {
+            // stores the default type of the class tree
+            getDefaultTypeFor(tree);
+
             Tree ext = tree.getExtendsClause();
             if (ext != null) {
                 defaultTypes.put(ext, realTypeFactory.getTypeOfExtendsImplements(ext));


### PR DESCRIPTION
Currently, all checkers in inference may crash on the following code:
```
public class VectorTest {
}

class Vector {
    int x;
    int y;
    int z;

    public static Vector max(Vector a, Vector b) {
        int aLength = a.length();
        int bLength = b.length();

        // test lub of polys
        if (aLength > bLength) {
            return a;
        }
        return b;
    }

    public int length() {
        return x * x + y * y + z * z;
    }
}
```
This is because `AbstractTypeProcessor::typeProcess` only receives one fully-analyzed top-level class at a time, while `SlotDefaultTypeResolver` tries to compute the default types for the entire compilation unit. Details about the crash:

1. The inference checker (which implements `AbstractTypeProcessor`) receives a call to type process the top-level class `VectorTest`.
2. Although the top-level class `Vector` is also under the same compilatioon unit tree, some of its fields in the internal `JCTree` implementation are not yet initialized (they are null).
3. `SlotDefaultTypeResolver` receives a call to find the default types for the entire compilation unit tree, and it will visit all type trees in the class `Vector`.
4. When `SlotDefaultTypeResolver` hits `int aLength` in `Vector::max`, it tries to get the ATM of `int` by calling `realTypeFactory.getAnnotatedTypeFromTypeTree`.
5. This call will use `AnnotatedTypeFactory::type(Tree node)`, in which we try to fetch the `TypeMirror` of this primitive type tree.
6. However, this primitive type tree is not fully initialized and the `TypeMirror` we get from javac is always null. So the program crashses.

To fix this issue, this PR introduces the following changes:
1. Added `getCurrentTopLevelClass()` to `InferenceChecker` so we can determine whether a tree is outside of the current processing scope.
2. Use the top level class to refresh default types cache, so `SlotDefaultTypeResolver` no longer process the entire compilation unit tree.

The test case has already been introduced in PR https://github.com/opprop/checker-framework-inference/pull/381
