### PR TITLE
Resolve Security Downstream Test

### DIFF
--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -27,11 +27,7 @@ import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
-import org.checkerframework.javacutil.AnnotationBuilder;
-import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.*;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -392,10 +388,16 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                                       "Current path:\n" + getVisitorTreePath();
 
         final ExecutableElement constructorElem = TreeUtils.constructor(newClassTree);;
-        @SuppressWarnings("deprecation") // TODO
-        final AnnotatedTypeMirror constructorReturnType = fromNewClass(newClassTree);
-        addComputedTypeAnnotations(newClassTree, constructorReturnType);
+        // Get the annotations written on the new class tree.
+        AnnotatedDeclaredType constructorReturnType =
+                (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(newClassTree), false);
+        // Get the enclosing type of the constructor, if one exists.
+        // this.new InnerClass()
+        AnnotatedDeclaredType enclosingType = (AnnotatedDeclaredType) getReceiverType(newClassTree);
+        constructorReturnType.setEnclosingType(enclosingType);
 
+        // Add computed annotations to the type.
+        addComputedTypeAnnotations(newClassTree, constructorReturnType);
         final AnnotatedExecutableType constructorType = AnnotatedTypes.asMemberOf(types, this, constructorReturnType, constructorElem);
 
         if (viewpointAdapter != null) {

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -27,7 +27,11 @@ import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
-import org.checkerframework.javacutil.*;
+import org.checkerframework.javacutil.AnnotationBuilder;
+import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.Pair;
+import org.checkerframework.javacutil.TreeUtils;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -363,6 +363,9 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     };
 
+    /**
+     * Override this method to re-add EnclosingType type into AnnotatedDeclaredType of a class.
+     */
     @Override
     @SuppressWarnings("deprecation")
     public AnnotatedDeclaredType fromNewClass(NewClassTree newClassTree) {

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -363,6 +363,17 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     };
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public AnnotatedDeclaredType fromNewClass(NewClassTree newClassTree) {
+        AnnotatedDeclaredType type = super.fromNewClass(newClassTree);
+        AnnotatedDeclaredType enclosingType = (AnnotatedDeclaredType) getReceiverType(newClassTree);
+        if (enclosingType != null) {
+            type.setEnclosingType(enclosingType);
+        }
+        return type;
+    }
+
     /**
      * TODO: Similar but not the same as AnnotatedTypeFactory.constructorFromUse with space set aside from
      * TODO: comb constraints, track down the differences with constructorFromUse

--- a/testdata/interning/SuperIterator.java
+++ b/testdata/interning/SuperIterator.java
@@ -18,8 +18,6 @@
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
-package no.uib.cipr.matrix.sparse;
-
 import java.util.Iterator;
 import java.util.List;
 

--- a/testdata/interning/SuperIterator.java
+++ b/testdata/interning/SuperIterator.java
@@ -1,156 +1,71 @@
-/*
- * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- *
- * This file is part of MTJ.
- *
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation; either version 2.1 of the License, or (at your
- * option) any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, write to the Free Software Foundation,
- * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- */
-
 import java.util.Iterator;
 import java.util.List;
-
-/**
- * An iterator over an array of iterable objects
- */
 class SuperIterator<T extends Iterable<E>, E> implements
         Iterator<SuperIterator.SuperIteratorEntry> {
-
     private List<T> iterable;
-
-    /**
-     * Two iterators. We need the "next" iterator so that hasNext works properly
-     * from one iterable to the next. Using a single iterator won't do
-     */
     private Iterator<E> current, next;
-
     private int currentIndex = 0, nextIndex = 0;
-
-    /**
-     * Recyled entry returned from next()
-     */
     private SuperIteratorEntry<E> entry;
-
-    /**
-     * Constructor for SuperIterator
-     *
-     * @param iterable
-     *            Iterable objects to iterate over
-     */
     public SuperIterator(List<T> iterable) {
         this.iterable = iterable;
         entry = new SuperIteratorEntry<E>();
-
-        // Try to be somewhat fault tolerant
-        if (iterable.size() == 0) {
+                if (iterable.size() == 0) {
             current = new DummyIterator();
             next = new DummyIterator();
         } else {
-
-            // This moves the next pointer to a non-empty iterable
-            next = iterable.get(nextIndex).iterator();
+                        next = iterable.get(nextIndex).iterator();
             moveNext();
-
-            // Then we move the current pointer in the same way
-            current = iterable.get(currentIndex).iterator();
+                        current = iterable.get(currentIndex).iterator();
             moveCurrent();
-
-            // Finally, move the next one step ahead if possible
-            if (next.hasNext())
+                        if (next.hasNext())
                 next.next();
         }
     }
-
     private void moveNext() {
         while (nextIndex < iterable.size() - 1 && !next.hasNext())
             next = iterable.get(++nextIndex).iterator();
     }
-
     private void moveCurrent() {
         while (currentIndex < iterable.size() - 1 && !current.hasNext())
             current = iterable.get(++currentIndex).iterator();
     }
-
     public boolean hasNext() {
         return current.hasNext() || next.hasNext();
     }
-
     public SuperIteratorEntry<E> next() {
-        // A wrapped object containing the relevant index and data
-        entry.update(currentIndex, current.next());
-
-        // Move current if necessary
-        moveCurrent();
-
-        // Move the next pointer
-        moveNext();
+                entry.update(currentIndex, current.next());
+                moveCurrent();
+                moveNext();
         if (next.hasNext())
             next.next();
-
         return entry;
     }
-
     public void remove() {
         current.remove();
     }
-
-    /**
-     * Dummy iterator, for degenerate cases
-     */
     private class DummyIterator implements Iterator<E> {
-
         public boolean hasNext() {
             return false;
         }
-
         public E next() {
             return null;
         }
-
         public void remove() {
             throw new UnsupportedOperationException();
         }
     }
-
-    /**
-     * Entry returned from this superiterator
-     */
     public static class SuperIteratorEntry<F> {
-
-        /**
-         * Index of the iterator which returned this
-         */
         private int i;
-
-        /**
-         * Object returned
-         */
         private F o;
-
         void update(int i, F o) {
             this.i = i;
             this.o = o;
         }
-
         public int index() {
             return i;
         }
-
         public F get() {
             return o;
         }
-
     }
-
 }

--- a/testdata/interning/SuperIterator.java
+++ b/testdata/interning/SuperIterator.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
+ *
+ * This file is part of MTJ.
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+package no.uib.cipr.matrix.sparse;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An iterator over an array of iterable objects
+ */
+class SuperIterator<T extends Iterable<E>, E> implements
+        Iterator<SuperIterator.SuperIteratorEntry> {
+
+    private List<T> iterable;
+
+    /**
+     * Two iterators. We need the "next" iterator so that hasNext works properly
+     * from one iterable to the next. Using a single iterator won't do
+     */
+    private Iterator<E> current, next;
+
+    private int currentIndex = 0, nextIndex = 0;
+
+    /**
+     * Recyled entry returned from next()
+     */
+    private SuperIteratorEntry<E> entry;
+
+    /**
+     * Constructor for SuperIterator
+     *
+     * @param iterable
+     *            Iterable objects to iterate over
+     */
+    public SuperIterator(List<T> iterable) {
+        this.iterable = iterable;
+        entry = new SuperIteratorEntry<E>();
+
+        // Try to be somewhat fault tolerant
+        if (iterable.size() == 0) {
+            current = new DummyIterator();
+            next = new DummyIterator();
+        } else {
+
+            // This moves the next pointer to a non-empty iterable
+            next = iterable.get(nextIndex).iterator();
+            moveNext();
+
+            // Then we move the current pointer in the same way
+            current = iterable.get(currentIndex).iterator();
+            moveCurrent();
+
+            // Finally, move the next one step ahead if possible
+            if (next.hasNext())
+                next.next();
+        }
+    }
+
+    private void moveNext() {
+        while (nextIndex < iterable.size() - 1 && !next.hasNext())
+            next = iterable.get(++nextIndex).iterator();
+    }
+
+    private void moveCurrent() {
+        while (currentIndex < iterable.size() - 1 && !current.hasNext())
+            current = iterable.get(++currentIndex).iterator();
+    }
+
+    public boolean hasNext() {
+        return current.hasNext() || next.hasNext();
+    }
+
+    public SuperIteratorEntry<E> next() {
+        // A wrapped object containing the relevant index and data
+        entry.update(currentIndex, current.next());
+
+        // Move current if necessary
+        moveCurrent();
+
+        // Move the next pointer
+        moveNext();
+        if (next.hasNext())
+            next.next();
+
+        return entry;
+    }
+
+    public void remove() {
+        current.remove();
+    }
+
+    /**
+     * Dummy iterator, for degenerate cases
+     */
+    private class DummyIterator implements Iterator<E> {
+
+        public boolean hasNext() {
+            return false;
+        }
+
+        public E next() {
+            return null;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Entry returned from this superiterator
+     */
+    public static class SuperIteratorEntry<F> {
+
+        /**
+         * Index of the iterator which returned this
+         */
+        private int i;
+
+        /**
+         * Object returned
+         */
+        private F o;
+
+        void update(int i, F o) {
+            this.i = i;
+            this.o = o;
+        }
+
+        public int index() {
+            return i;
+        }
+
+        public F get() {
+            return o;
+        }
+
+    }
+
+}


### PR DESCRIPTION
In this PR, I overrided the method **fromNewClass** in **InferenceAnnotatedTypeFactory**, adding enclosing type into AnnotatedDeclaredType of a class, this can solve the problem of this pr: https://github.com/opprop/checker-framework-inference/pull/395.

This PR also removes the deprecated usage of `fromNewClass`, where the logic is similar to https://github.com/eisop/checker-framework/blob/b8b16a34a6e6d6a4621964ad4a1b2ed69fac5ddc/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java#L2670

I have tested all test cases including downstream tests in my local environment.

If it makes sense, PR https://github.com/eisop/checker-framework/pull/267 should be merged first because it dependents on it.