### PR TITLE
Update maven and gradle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install ant cpp gradle jq libcurl3-gnutls make maven mercurial python3-requests unzip wget binutils build-essential
+          sudo apt install ant cpp gradle jq libcurl3-gnutls make mercurial python3-requests unzip wget binutils build-essential
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.4
+        with:
+          maven-version: 3.8.6
       - name: Pull Request Checkout
         uses: actions/checkout@v2
         with:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
To fix all downstream Java 17 tests, we need the following changes:
1. Use maven 3.8.6 which supports JDK 17
2. Create a fork of https://github.com/hwinkler/matrix-toolkits-java at https://github.com/opprop-benchmarks/hwinkler-matrix-toolkits-java so that we can update its compile source and target to 1.8.
3. Update other projects (in https://github.com/opprop-benchmark) that are used by downstream projects. We need to make sure their compile source and target are >= 1.7.
4. Update security-demo: https://github.com/opprop/security-demo/pull/19
5. Update ontology: https://github.com/opprop/ontology/pull/78