### PR TITLE
Get default type for new class tree

### DIFF
--- a/src/checkers/inference/util/SlotDefaultTypeResolver.java
+++ b/src/checkers/inference/util/SlotDefaultTypeResolver.java
@@ -3,6 +3,7 @@ package checkers.inference.util;
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
@@ -184,6 +185,13 @@ public class SlotDefaultTypeResolver {
             defaultTypes.put(tree.getUnderlyingType(), defaultType);
 
             return super.visitAnnotatedType(tree, unused);
+        }
+
+        @Override
+        public Void visitNewClass(NewClassTree tree, Void unused) {
+            AnnotatedTypeMirror defaultType = getDefaultTypeFor(tree);
+            defaultTypes.put(tree.getIdentifier(), defaultType);
+            return super.visitNewClass(tree, unused);
         }
     }
 }


### PR DESCRIPTION
Previously, for new class tree like `new @Slot1 ArrayList<String>();` the default type for slot1 was derived by visiting the identifier tree, not the new class tree. By overriding this method, the default type for slot1 now is derived by visiting the new class tree, which is a more precise context for annotating.

And I don't think we have to do anything else, like getting the default type for the `String` in the above example, as the new method will recursively call `visitParameterizedType` and do corresponding things there.