### PR TITLE
Remove use of no-longer-existing jdk8.jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,6 @@ task dist(dependsOn: shadowJar, type: Copy) {
             "will build checker-framework-inference.jar, copy all the relevant runtime jars into " +
             "the dist directory."
     from files(
-            "${checkerFrameworkPath}/checker/dist/jdk8.jar",
             "${checkerFrameworkPath}/checker/dist/checker.jar",
             "${checkerFrameworkPath}/checker/dist/checker-qual.jar",
             "${checkerFrameworkPath}/checker/dist/checker-util.jar",


### PR DESCRIPTION
Based on the CHANGELOG, 

Version 3.4.0 (May 3, 2020)
---------------------------

The annotated jdk8.jar is no longer used.  You should remove any occurrence of
  -Xbootclasspath/p:.../jdk8.jar
from your build scripts.  Annotations for JDK 8 are included in checker.jar.

I have removed the jdk8.jar in the task dist.