### PR TITLE
Replace broken APIs

### DIFF
--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -34,7 +34,7 @@ libDir="$cfiDir"/lib
 CFBuild="${cfDir}"/dataflow/"${classes}":"${cfDir}"/javacutil/"${classes}":"${cfDir}"/framework/"${classes}":"${cfDir}"/framework/"${resources}"
 CFBuild="${CFBuild}":"${cfDir}"/checker/"${classes}":"${cfDir}"/checker/"${resources}":"${annoToolsDir}"/scene-lib/bin
 
-CFDepJars="${stubparserDir}"/javaparser-core/target/stubparser-3.24.7.jar:"${afuDir}"/annotation-file-utilities-all.jar
+CFDepJars="${stubparserDir}"/javaparser-core/target/stubparser-3.25.2.jar:"${afuDir}"/annotation-file-utilities-all.jar
 
 # sanity check: ensure each jar in CFDepJars actually exists in the file system
 # total number of jars

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -24,7 +24,7 @@ import org.checkerframework.framework.type.typeannotator.ListTypeAnnotator;
 import org.checkerframework.framework.type.typeannotator.TypeAnnotator;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
-import org.checkerframework.framework.util.AnnotationMirrorSet;
+import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
 import org.checkerframework.javacutil.AnnotationBuilder;

--- a/src/checkers/inference/InferenceAnnotatedTypeFactory.java
+++ b/src/checkers/inference/InferenceAnnotatedTypeFactory.java
@@ -570,11 +570,11 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * @return the singleton set with the {@link VarAnnot} on the class bound
      */
     @Override
-    public Set<AnnotationMirror> getTypeDeclarationBounds(TypeMirror type) {
+    public AnnotationMirrorSet getTypeDeclarationBounds(TypeMirror type) {
         final TypeElement elt = (TypeElement) getProcessingEnv().getTypeUtils().asElement(type);
         AnnotationMirror vAnno = variableAnnotator.getClassDeclVarAnnot(elt);
         if (vAnno != null) {
-            return Collections.singleton(vAnno);
+            return new AnnotationMirrorSet(Collections.singleton(vAnno));
         }
 
         // This is to handle the special case of anonymous classes when the super class (or interface)
@@ -587,11 +587,11 @@ public class InferenceAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (realAnno != null) {
             Slot slot = slotManager.getSlot(realAnno);
             vAnno = slotManager.getAnnotation(slot);
-            return Collections.singleton(vAnno);
+            return new AnnotationMirrorSet(Collections.singleton(vAnno));
         }
 
         // If the declaration bound of the underlying type is not cached, use default
-        return (Set<AnnotationMirror>) getDefaultTypeDeclarationBounds();
+        return (AnnotationMirrorSet) getDefaultTypeDeclarationBounds();
     }
 
     /**

--- a/src/checkers/inference/InferenceQualifierHierarchy.java
+++ b/src/checkers/inference/InferenceQualifierHierarchy.java
@@ -10,7 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.ElementQualifierHierarchy;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.util.AnnotationMirrorSet;
+import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.framework.util.DefaultQualifierKindHierarchy;
 import org.checkerframework.framework.util.QualifierKind;
 import org.checkerframework.framework.util.QualifierKindHierarchy;

--- a/src/checkers/inference/dataflow/InferenceAnalysis.java
+++ b/src/checkers/inference/dataflow/InferenceAnalysis.java
@@ -15,6 +15,7 @@ import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
+import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.Pair;
 
@@ -71,7 +72,7 @@ public class InferenceAnalysis extends CFAnalysis {
      */
     @Override
     public CFValue defaultCreateAbstractValue(CFAbstractAnalysis<CFValue, ?, ?> analysis,
-                                              Set<AnnotationMirror> annos,
+                                              AnnotationMirrorSet annos,
                                               TypeMirror underlyingType) {
 
         if (annos.size() == 0 && underlyingType.getKind() != TypeKind.TYPEVAR) {

--- a/src/checkers/inference/dataflow/InferenceValue.java
+++ b/src/checkers/inference/dataflow/InferenceValue.java
@@ -7,6 +7,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotationFormatter;
+import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.TypesUtils;
 
 import java.util.Collections;
@@ -37,7 +38,7 @@ import checkers.inference.model.ConstantSlot;
 public class InferenceValue extends CFValue {
 
 
-    public InferenceValue(InferenceAnalysis analysis, Set<AnnotationMirror> annotations, TypeMirror underlyingType) {
+    public InferenceValue(InferenceAnalysis analysis, AnnotationMirrorSet annotations, TypeMirror underlyingType) {
         super(analysis, annotations, underlyingType);
     }
 
@@ -69,7 +70,7 @@ public class InferenceValue extends CFValue {
         // the two VarAnnos getting from slotManager.
         final AnnotationMirror lub = qualifierHierarchy.leastUpperBound(anno1, anno2);
 
-        return analysis.createAbstractValue(Collections.singleton(lub), getLubType(other, null));
+        return analysis.createAbstractValue(new AnnotationMirrorSet(Collections.singleton(lub)), getLubType(other, null));
     }
 
     public Slot getEffectiveSlot(final CFValue value) {


### PR DESCRIPTION
I have encountered a lot of errors while I am build the project. I try to fix them in this PR.

Also, in https://github.com/eisop/checker-framework/blob/ed990541a50116e8e5676062219aba2a0a3efe88/docs/CHANGELOG.md?plain=1#L180 `createAnnotationMap` and `createAnnotationSet` are removed from the project. However, they are heavily used in this inference project. We should have a discussion about whether bring them back to EISOP or not.