### PR TITLE
Share test JVM argument configuration across all Gradle Test tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,16 @@ task buildDLJC(type: Exec) {
     commandLine './buildDLJC'
 }
 
+def configureTestJvmArgs = { Test testTask ->
+    if (isJava8) {
+        testTask.jvmArgs += [
+            "-Xbootclasspath/p:${configurations.javacJar.asPath}"
+        ]
+    } else {
+        testTask.jvmArgs += compilerArgsForRunningCF
+    }
+}
+
 test {
     dependsOn(shadowJar)
     dependsOn('dist')
@@ -176,17 +186,6 @@ test {
 
     if (project.hasProperty('emit.test.debug')) {
         systemProperties += ["emit.test.debug": 'true']
-    }
-
-    if (isJava8) {
-        jvmArgs += [
-            "-Xbootclasspath/p:${configurations.javacJar.asPath}"
-        ]
-    } else {
-        // Without this, the test throw "java.lang.OutOfMemoryError: Java heap space"
-        // Corresponding pull request: https://github.com/opprop/checker-framework-inference/pull/263
-        forkEvery(1)
-        jvmArgs += compilerArgsForRunningCF
     }
 
     testLogging {
@@ -373,11 +372,7 @@ afterEvaluate {
             systemProperties += ["emit.test.debug": 'true']
         }
 
-        if (isJava8) {
-            jvmArgs += [
-                "-Xbootclasspath/p:${configurations.javacJar.asPath}"
-            ]
-        }
+        configureTestJvmArgs(delegate)
 
         testLogging {
             // Always run the tests


### PR DESCRIPTION
The aggregate `test` task already configured Java 8 bootclasspath args and JDK 9+ module export/open args, but generated per-class test tasks like `OsTrustedTest` only had the Java 8 path.

This change moves that JVM-args selection into a shared helper and applies it through `tasks.withType(Test)`, so both `./gradlew test` and generated per-class tasks use the same Java version handling.

It also removes the stale `forkEvery(1)` workaround now that the underlying issue has been fixed.